### PR TITLE
move lib:graphql to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,6 @@
     "prebuild": "npm run clean",
     "prepublishOnly": "npm run build"
   },
-  "peerDependencies": {
-    "graphql": "^0.13.0 || ^14.0.0"
-  },
   "devDependencies": {
     "@types/figures": "2.0.0",
     "@types/glob": "7.1.1",
@@ -44,7 +41,6 @@
     "@types/log-symbols": "2.0.0",
     "@types/node-fetch": "2.1.3",
     "@types/opn": "5.1.0",
-    "graphql": "14.0.2",
     "graphql-tag": "2.10.0",
     "jest": "23.6.0",
     "lint-staged": "8.0.4",
@@ -58,6 +54,7 @@
     "commander": "2.19.0",
     "figures": "2.0.0",
     "glob": "7.1.3",
+    "graphql": "14.0.2",
     "is-glob": "4.0.0",
     "is-valid-path": "0.1.1",
     "log-symbols": "2.2.0",


### PR DESCRIPTION
issue: https://github.com/kamilkisiela/graphql-inspector/issues/7

`peerDependencies` is not automatic install after npm v3. And if `graphql-inspector` is working as a cli tool, then graphql should be in dependencies list, not devDependencies.