### PR TITLE
bugfix: filter fragments which are in the document before validation

### DIFF
--- a/packages/core/src/validate/index.ts
+++ b/packages/core/src/validate/index.ts
@@ -41,7 +41,10 @@ export function validate(
       parse(`
           ${doc.source.body}
 
-          ${fragments.map(print).join('\n\n')}
+          ${fragments
+            .filter(f => doc.source.body.indexOf(`fragment ${f.name.value} on`))
+            .map(print)
+            .join('\n\n')}
         `),
     ) as GraphQLError[];
     const deprecated = findDeprecatedUsages(schema, parse(doc.source.body));


### PR DESCRIPTION
Related to #36

@kamilkisiela I simply filter out the fragments if they are in the document otherwise there might be double fragments, but if they are always in the document we could probably just remove some code instead of adding ;). 