### PR TITLE
Add array comparison to diffing

### DIFF
--- a/packages/core/__tests__/diff/schema.ts
+++ b/packages/core/__tests__/diff/schema.ts
@@ -136,6 +136,10 @@ test('huge test', () => {
       a: String = "1"
       b: String!
     }
+    input ListInput {
+      a: [String] = ["foo"]
+      b: [String] = ["bar"]
+    }
     """
     The Query Root of this schema
     """
@@ -208,6 +212,10 @@ test('huge test', () => {
       """
       a: Int = 1
       c: String!
+    }
+    input ListInput {
+      a: [String] = ["bar"]
+      b: [String] = ["bar"]
     }
     """
     Query Root description changed
@@ -292,6 +300,7 @@ test('huge test', () => {
     `Input field 'c' was added to input object type 'AInput'`,
     `Input field 'AInput.a' description changed from 'a' to 'changed'`,
     `Input field 'AInput.a' default value changed from '1' to '1'`,
+    `Input field 'ListInput.a' default value changed from 'foo' to 'bar'`,
     `Input field 'AInput.a' changed type from 'String' to 'Int'`,
     `'CType' object implements 'AnInterface' interface`,
     `Field 'c' was removed from object type 'CType'`,
@@ -326,6 +335,7 @@ test('huge test', () => {
     try {
       expect(changes.some(c => c.message === msg)).toEqual(true);
     } catch (e) {
+      console.log(changes);
       console.log(`Couldn't find: ${msg}`);
       const match = findBestMatch(
         msg,

--- a/packages/core/src/diff/common/compare.ts
+++ b/packages/core/src/diff/common/compare.ts
@@ -1,4 +1,16 @@
 export function isEqual<T>(a: T, b: T): boolean {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+
+    for (var index = 0; index < a.length; index++) {
+      if (a[index] !== b[index]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   return a === b || (!a && !b);
 }
 


### PR DESCRIPTION
I noticed that if you have a default argument that was an array, that the schema diffing would report a warning. This adds logic in the value comparison to check the contents of arrays. I also added a test for this case.