### PR TITLE
Allow from-git to also work with introspection results

### DIFF
--- a/packages/load/src/schema/from-git.ts
+++ b/packages/load/src/schema/from-git.ts
@@ -1,5 +1,5 @@
 import * as simplegit from 'simple-git/promise';
-import {buildSchema} from 'graphql';
+import {buildSchema, buildClientSchema} from 'graphql';
 
 import {SchemaHandler} from './loader';
 
@@ -44,6 +44,14 @@ export const fromGit: SchemaHandler = function fromGit(pointer) {
 
       if (/\.(gql|graphql)$/i.test(path)) {
         return buildSchema(schemaString);
+      }
+
+      if (/\.json$/i.test(path)) {
+        try {
+          return buildClientSchema(JSON.parse(schemaString));
+        } catch (error) {
+          throw new Error('unable to build schema from introspection result');
+        }
       }
 
       throw new Error('Unable to build schema from git');


### PR DESCRIPTION
This makes it so `from-git` also supports building a schema from an introspection results file.