### PR TITLE
Make the docker image suitable for CI and document usage

### DIFF
--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -9,9 +9,5 @@ ENV LOG_LEVEL "debug"
 
 RUN yarn global add @graphql-inspector/cli@1.24.0 graphql
 
-COPY ./entrypoint-cli.sh .
-
-RUN ["chmod", "+x", "/entrypoint-cli.sh"]
-
-ENTRYPOINT ["/entrypoint-cli.sh"]
-
+RUN mkdir /app
+WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Inspector](https://user-images.githubusercontent.com/25294569/64163641-50cc9f80-ce4a-11e9-89b0-248c7d12142f.gif)](https://graphql-inspector.com/)
 
 [![npm version](https://badge.fury.io/js/%40graphql-inspector%2Fcli.svg)](https://npmjs.com/package/@graphql-inspector/cli)
+![Docker Pulls](https://img.shields.io/docker/pulls/kamilkisiela/graphql-inspector)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![renovate-app badge](https://img.shields.io/badge/renovate-app-blue.svg)](https://renovateapp.com/)
 [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/graphql-inspector)
@@ -20,6 +21,7 @@ Major features:
 - **Serves a GraphQL server with faked data and GraphQL Playground**
 - **Github Bot**
 - **Github Actions**
+- **Docker Image**
 
 GraphQL Inspector has a **CLI** and also a **programatic API**, so you can use it however you want to and even build tools on top of it.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,3 +41,21 @@ npm install --save @graphql-inspector/core
 ```typescript
 import { ... } from '@graphql-inspector/core';
 ```
+
+## Docker
+
+```bash
+docker run kamilkisiela/graphql-inspector --help
+```
+
+Bind volumes to `/app` for working with local files, for example:
+
+```bash
+docker run -v $PWD:/app kamilkisiela/graphql-inspector graphql-inspector diff old.graphql new.graphql
+```
+
+To run commands interactively inside of the container, use the following:
+
+```bash
+docker run -it kamilkisiela/graphql-inspector
+```

--- a/docs/recipes/ci.md
+++ b/docs/recipes/ci.md
@@ -18,12 +18,9 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:12.4.0
+      - image: kamilkisiela/graphql-inspector
     steps:
       - checkout
-      - run:
-          name: Install
-          command: yarn install
       - run:
           name: GraphQL Inspector
           command: 'graphql-inspector diff "git:origin/master:./schema.graphql" "schema.graphql"'


### PR DESCRIPTION
Resolves #552

The previous entrypoint makes it hard to work with the image in CI. Providers such as CircleCI or GitLabCI typically expect to be able to enter into a shell.

Added a badge and some docs around docker image usage.