### PR TITLE
Fix enum diff method to compare using the same property

### DIFF
--- a/packages/core/src/diff/enum.ts
+++ b/packages/core/src/diff/enum.ts
@@ -16,7 +16,7 @@ export function changesInEnum(
 ): Change[] {
   const changes: Change[] = [];
   const oldNames = oldEnum.getValues().map(v => v.value);
-  const newNames = newEnum.getValues().map(v => v.name);
+  const newNames = newEnum.getValues().map(v => v.value);
 
   const added = diffArrays(newNames, oldNames).map(
     name => newEnum.getValue(name) as GraphQLEnumValue,


### PR DESCRIPTION
Compare enum using the `value` for both enums (old and new).

Fix #881