### PR TITLE
Add types field to package.json

### DIFF
--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -12,6 +12,7 @@
   ],
   "sideEffects": false,
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "author": {
     "name": "Kamil Kisiela",
     "email": "kamil.kisiela@gmail.com",


### PR DESCRIPTION
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package

I'm getting import suggestions from `@graphql-inspector/core/dist` instead of from `@graphql-inspectore/core`. The latter should work given that there's an existing `"main": "dist/index.js"`.