### PR TITLE
BREAKING: don't use preceding comments as the description by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **action** use original SHA, not SHA from `pull_request` event [PR #1440](https://github.com/kamilkisiela/graphql-inspector/pull/1440)
 - **github** **action** assume valid schema to avoid missing directive definitions [PR #1440](https://github.com/kamilkisiela/graphql-inspector/pull/1440)
 - **cli** **ci** fix `--header` and `--token` [PR #1442](https://github.com/kamilkisiela/graphql-inspector/pull/1442)
+- **cli** **ci** BREAKING: don't use preceding comments as the description by default (`--comments` flag to enable comments) [PR #1443](https://github.com/kamilkisiela/graphql-inspector/pull/1443)
 
 ### v1.30.4
 

--- a/bob.config.js
+++ b/bob.config.js
@@ -14,7 +14,7 @@ module.exports = {
     test: {
       track: ['jest.config.js', '<project>/jest.config.js', '<project>/__tests__/**'],
       run(affected) {
-        return [`yarn`, ['test', ...affected.paths]];
+        return [`yarn`, ['test', '--passWithNoTests', ...affected.paths]];
       },
     },
     build: {

--- a/packages/commands/introspect/src/index.ts
+++ b/packages/commands/introspect/src/index.ts
@@ -13,6 +13,7 @@ export default createCommand<
   {
     schema: string;
     write?: string;
+    comments?: boolean;
   } & GlobalArgs
 >((api) => {
   return {
@@ -30,6 +31,10 @@ export default createCommand<
             alias: 'write',
             describe: 'Write to a file',
             type: 'string',
+          },
+          comments: {
+            describe: 'Use preceding comments as the description',
+            type: 'boolean',
           },
         })
         .default('w', 'graphql.schema.json');
@@ -53,7 +58,7 @@ export default createCommand<
         case '.gqls':
         case '.graphqls':
           content = printSchema(schema, {
-            commentDescriptions: true,
+            commentDescriptions: args.comments || false
           });
           break;
         case '.json':


### PR DESCRIPTION
`--comments` flag to enable comments