### PR TITLE
Add change types for added/removed deprecation reason on enum values

### DIFF
--- a/packages/core/__tests__/diff/enum.ts
+++ b/packages/core/__tests__/diff/enum.ts
@@ -142,4 +142,70 @@ describe('enum', () => {
       `Enum value 'enumA.A' deprecation reason changed from 'Old Reason' to 'New Reason'`,
     );
   });
+
+  test('deprecation reason added', () => {
+    const a = buildSchema(/* GraphQL */ `
+      type Query {
+        fieldA: String
+      }
+
+      enum enumA {
+        A
+        B
+      }
+    `);
+
+    const b = buildSchema(/* GraphQL */ `
+      type Query {
+        fieldA: String
+      }
+
+      enum enumA {
+        A @deprecated(reason: "New Reason")
+        B
+      }
+    `);
+
+    const changes = diff(a, b);
+    const change = findFirstChangeByPath(changes, 'enumA.A');
+
+    expect(changes.length).toEqual(1);
+    expect(change.criticality.level).toEqual(CriticalityLevel.NonBreaking);
+    expect(change.message).toEqual(
+      `Enum value 'enumA.A' was deprecated with reason 'New Reason'`,
+    );
+  });
+
+  test('deprecation reason removed', () => {
+    const a = buildSchema(/* GraphQL */ `
+      type Query {
+        fieldA: String
+      }
+
+      enum enumA {
+        A @deprecated(reason: "New Reason")
+        B
+      }
+    `);
+
+    const b = buildSchema(/* GraphQL */ `
+    type Query {
+      fieldA: String
+    }
+
+    enum enumA {
+      A
+      B
+    }
+    `);
+
+    const changes = diff(a, b);
+    const change = findFirstChangeByPath(changes, 'enumA.A');
+
+    expect(changes.length).toEqual(1);
+    expect(change.criticality.level).toEqual(CriticalityLevel.NonBreaking);
+    expect(change.message).toEqual(
+      `Deprecation reason was removed from enum value 'enumA.A'`,
+    );
+  });
 });

--- a/packages/core/src/diff/changes/change.ts
+++ b/packages/core/src/diff/changes/change.ts
@@ -19,6 +19,8 @@ export enum ChangeType {
   EnumValueAdded = 'ENUM_VALUE_ADDED',
   EnumValueDescriptionChanged = 'ENUM_VALUE_DESCRIPTION_CHANGED',
   EnumValueDeprecationReasonChanged = 'ENUM_VALUE_DEPRECATION_REASON_CHANGED',
+  EnumValueDeprecationReasonAdded = 'ENUM_VALUE_DEPRECATION_REASON_ADDED',
+  EnumValueDeprecationReasonRemoved = 'ENUM_VALUE_DEPRECATION_REASON_REMOVED',
   // Field
   FieldRemoved = 'FIELD_REMOVED',
   FieldAdded = 'FIELD_ADDED',

--- a/packages/core/src/diff/changes/enum.ts
+++ b/packages/core/src/diff/changes/enum.ts
@@ -59,10 +59,38 @@ export function enumValueDeprecationReasonChanged(
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
-    type: ChangeType.EnumValueDescriptionChanged,
-    message: oldValue.deprecationReason
-      ? `Enum value '${newEnum.name}.${newValue.name}' deprecation reason changed from '${oldValue.deprecationReason}' to '${newValue.deprecationReason}'`
-      : `Enum value '${newEnum.name}.${newValue.name}' was deprecated with reason '${newValue.deprecationReason}'`,
+    type: ChangeType.EnumValueDeprecationReasonChanged,
+    message: `Enum value '${newEnum.name}.${newValue.name}' deprecation reason changed from '${oldValue.deprecationReason}' to '${newValue.deprecationReason}'`,
+    path: [newEnum.name, oldValue.name].join('.'),
+  };
+}
+
+export function enumValueDeprecationReasonAdded(
+  newEnum: GraphQLEnumType,
+  oldValue: GraphQLEnumValue,
+  newValue: GraphQLEnumValue,
+): Change {
+  return {
+    criticality: {
+      level: CriticalityLevel.NonBreaking,
+    },
+    type: ChangeType.EnumValueDeprecationReasonAdded,
+    message: `Enum value '${newEnum.name}.${newValue.name}' was deprecated with reason '${newValue.deprecationReason}'`,
+    path: [newEnum.name, oldValue.name].join('.'),
+  };
+}
+
+export function enumValueDeprecationReasonRemoved(
+  newEnum: GraphQLEnumType,
+  oldValue: GraphQLEnumValue,
+  newValue: GraphQLEnumValue,
+): Change {
+  return {
+    criticality: {
+      level: CriticalityLevel.NonBreaking,
+    },
+    type: ChangeType.EnumValueDeprecationReasonRemoved,
+    message: `Deprecation reason was removed from enum value '${newEnum.name}.${newValue.name}'`,
     path: [newEnum.name, oldValue.name].join('.'),
   };
 }

--- a/packages/core/src/diff/enum.ts
+++ b/packages/core/src/diff/enum.ts
@@ -1,11 +1,13 @@
 import {GraphQLEnumType, GraphQLEnumValue} from 'graphql';
 
-import {isNotEqual} from './common/compare';
+import {isNotEqual, isVoid} from './common/compare';
 import {
   enumValueRemoved,
   enumValueAdded,
   enumValueDescriptionChanged,
   enumValueDeprecationReasonChanged,
+  enumValueDeprecationReasonAdded,
+  enumValueDeprecationReasonRemoved,
 } from './changes/enum';
 import {Change} from './changes/change';
 import {unionArrays, diffArrays} from '../utils/arrays';
@@ -38,9 +40,13 @@ export function changesInEnum(
     }
 
     if (isNotEqual(oldValue.deprecationReason, newValue.deprecationReason)) {
-      changes.push(
-        enumValueDeprecationReasonChanged(newEnum, oldValue, newValue),
-      );
+      if (isVoid(oldValue.deprecationReason)) {
+        changes.push(enumValueDeprecationReasonAdded(newEnum, oldValue, newValue));
+      } else if (isVoid(newValue.deprecationReason)) {
+        changes.push(enumValueDeprecationReasonRemoved(newEnum, oldValue, newValue));
+      } else {
+        changes.push(enumValueDeprecationReasonChanged(newEnum, oldValue, newValue));
+      }
     }
   });
 


### PR DESCRIPTION
- Fixes the `type` returned by `enumValueDeprecationReasonChanged` (was `EnumValueDescriptionChanged`).
- Adds two additional change types for enum value deprecations (added and removed) to match behavior with fields