### PR TITLE
Bug Fix: No deprecation notice for field on fragment in a different document

### DIFF
--- a/packages/core/src/validate/index.ts
+++ b/packages/core/src/validate/index.ts
@@ -3,7 +3,6 @@ import {
   GraphQLError,
   Source,
   print,
-  parse,
   validate as validateDocument,
   FragmentDefinitionNode,
   DocumentNode,
@@ -147,7 +146,7 @@ export function validate(
       }
 
       const deprecated = config.strictDeprecated
-        ? findDeprecatedUsages(transformedSchema, parse(doc.source.body))
+        ? findDeprecatedUsages(transformedSchema, transformedDoc)
         : [];
       const duplicatedFragments = config.strictFragments
         ? findDuplicatedFragments(fragmentNames)


### PR DESCRIPTION
## Description

There is currently no deprecated warning raised when using a deprecated field on a fragment, where that fragment is used on an operation in a different document. The culprit appears to be not passing the transformed version of the operation document (includes fragments from other documents) into `findDeprecatedUsages`. Included failing test case and fix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
