### PR TITLE
Multiple headers for different remote URLs

### DIFF
--- a/packages/ci/src/index.ts
+++ b/packages/ci/src/index.ts
@@ -31,12 +31,12 @@ async function main() {
         type: 'array',
       },
       hl: {
-        alias: 'leftheader',
+        alias: 'left-header',
         describe: 'Http Header - Left',
         type: 'array',
       },
       hr: {
-        alias: 'rightheader',
+        alias: 'right-header',
         describe: 'Http Header - Right',
         type: 'array',
       },

--- a/packages/ci/src/index.ts
+++ b/packages/ci/src/index.ts
@@ -1,8 +1,8 @@
-import {useConfig, availableCommands} from '@graphql-inspector/config';
-import {useCommands} from '@graphql-inspector/commands';
-import {useLoaders} from '@graphql-inspector/loaders';
-import yargs, {Argv} from 'yargs';
-import {Logger} from '@graphql-inspector/logger';
+import { useCommands } from '@graphql-inspector/commands';
+import { availableCommands, useConfig } from '@graphql-inspector/config';
+import { useLoaders } from '@graphql-inspector/loaders';
+import { Logger } from '@graphql-inspector/logger';
+import yargs, { Argv } from 'yargs';
 
 async function main() {
   const config = await useConfig();
@@ -28,6 +28,16 @@ async function main() {
       h: {
         alias: 'header',
         describe: 'Http Header',
+        type: 'array',
+      },
+      hl: {
+        alias: 'leftheader',
+        describe: 'Http Header - Left',
+        type: 'array',
+      },
+      hr: {
+        alias: 'rightheader',
+        describe: 'Http Header - Right',
         type: 'array',
       },
     });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
-import {useCommands} from '@graphql-inspector/commands';
-import {useLoaders} from '@graphql-inspector/loaders';
-import yargs, {Argv} from 'yargs';
+import { useCommands } from '@graphql-inspector/commands';
+import { useLoaders } from '@graphql-inspector/loaders';
+import yargs, { Argv } from 'yargs';
 
 async function main() {
   const config = {
@@ -37,6 +37,16 @@ async function main() {
       h: {
         alias: 'header',
         describe: 'Http Header',
+        type: 'array',
+      },
+      hl: {
+        alias: 'leftheader',
+        describe: 'Http Header - Left',
+        type: 'array',
+      },
+      hr: {
+        alias: 'rightheader',
+        describe: 'Http Header - Right',
         type: 'array',
       },
     });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -40,12 +40,12 @@ async function main() {
         type: 'array',
       },
       hl: {
-        alias: 'leftheader',
+        alias: 'left-header',
         describe: 'Http Header - Left',
         type: 'array',
       },
       hr: {
-        alias: 'rightheader',
+        alias: 'right-header',
         describe: 'Http Header - Right',
         type: 'array',
       },

--- a/packages/commands/commands/src/index.ts
+++ b/packages/commands/commands/src/index.ts
@@ -39,8 +39,8 @@ export interface GlobalArgs {
   require?: string[];
   token?: string;
   header?: string[];
-  leftheader?: string[];
-  rightheader?: string[];
+  leftHeader?: string[];
+  rightHeader?: string[];
   federation?: boolean;
   aws?: boolean;
   method?: string;
@@ -59,16 +59,16 @@ export function parseGlobalArgs(args: GlobalArgs) {
     });
   }
 
-  if (args.leftheader) {
-    args.leftheader.forEach((leftHeader) => {
+  if (args.leftHeader) {
+    args.leftHeader.forEach((leftHeader) => {
       const [lname, ...lvalues] = leftHeader.split(':');
 
       leftHeaders[lname] = lvalues.join('');
     });
   }
 
-  if (args.rightheader) {
-    args.rightheader.forEach((rightHeader) => {
+  if (args.rightHeader) {
+    args.rightHeader.forEach((rightHeader) => {
       const [rname, ...rvalues] = rightHeader.split(':');
 
       rightHeaders[rname] = rvalues.join('');

--- a/packages/commands/commands/src/index.ts
+++ b/packages/commands/commands/src/index.ts
@@ -1,10 +1,9 @@
-import {InspectorConfig} from '@graphql-inspector/config';
-import {Loaders} from '@graphql-inspector/loaders';
-import {isAbsolute, resolve} from 'path';
-import {CommandModule as Command} from 'yargs';
-import yargs from 'yargs';
+import { InspectorConfig } from '@graphql-inspector/config';
+import { Loaders } from '@graphql-inspector/loaders';
+import { isAbsolute, resolve } from 'path';
+import yargs, { CommandModule as Command } from 'yargs';
 
-export {Command};
+export { Command };
 
 export interface UseCommandsAPI {
   config: InspectorConfig;
@@ -40,6 +39,8 @@ export interface GlobalArgs {
   require?: string[];
   token?: string;
   header?: string[];
+  leftheader?: string[];
+  rightheader?: string[];
   federation?: boolean;
   aws?: boolean;
   method?: string;
@@ -47,6 +48,8 @@ export interface GlobalArgs {
 
 export function parseGlobalArgs(args: GlobalArgs) {
   const headers: Record<string, string> = {};
+  const leftHeaders: Record<string, string> = {};
+  const rightHeaders: Record<string, string> = {};
 
   if (args.header) {
     args.header.forEach((header) => {
@@ -56,11 +59,27 @@ export function parseGlobalArgs(args: GlobalArgs) {
     });
   }
 
+  if (args.leftheader) {
+    args.leftheader.forEach((leftHeader) => {
+      const [lname, ...lvalues] = leftHeader.split(':');
+
+      leftHeaders[lname] = lvalues.join('');
+    });
+  }
+
+  if (args.rightheader) {
+    args.rightheader.forEach((rightHeader) => {
+      const [rname, ...rvalues] = rightHeader.split(':');
+
+      rightHeaders[rname] = rvalues.join('');
+    });
+  }
+
   if (args.require) {
     args.require.forEach((mod) => require(mod));
   }
 
-  return {headers, token: args.token};
+  return {headers, leftHeaders, rightHeaders, token: args.token};
 }
 
 export async function mockCommand(mod: Command, cmd: string) {

--- a/packages/commands/diff/src/index.ts
+++ b/packages/commands/diff/src/index.ts
@@ -1,24 +1,25 @@
 import {
-  createCommand,
+  CommandFactory, createCommand,
   ensureAbsolute,
-  parseGlobalArgs,
-  GlobalArgs,
-  CommandFactory,
-} from '@graphql-inspector/commands';
-import {symbols, Logger, bolderize} from '@graphql-inspector/logger';
-import {
-  diff as diffSchema,
-  CriticalityLevel,
-  Change,
-  DiffRule,
-  Rule,
-  CompletionHandler,
-  CompletionArgs,
-} from '@graphql-inspector/core';
-import {existsSync} from 'fs';
-import {GraphQLSchema} from 'graphql';
 
-export {CommandFactory};
+  GlobalArgs, parseGlobalArgs
+} from '@graphql-inspector/commands';
+import {
+  Change,
+
+
+
+  CompletionArgs, CompletionHandler, CriticalityLevel, diff as diffSchema,
+
+
+  DiffRule,
+  Rule
+} from '@graphql-inspector/core';
+import { bolderize, Logger, symbols } from '@graphql-inspector/logger';
+import { existsSync } from 'fs';
+import { GraphQLSchema } from 'graphql';
+
+export { CommandFactory };
 
 export function handler(input: {
   oldSchema: GraphQLSchema;
@@ -127,12 +128,15 @@ export default createCommand<
         const apolloFederation = args.federation || false;
         const aws = args.aws || false;
         const method = args.method?.toUpperCase() || 'POST';
-        const {headers, token} = parseGlobalArgs(args);
+        const {headers, leftHeaders, rightHeaders, token} = parseGlobalArgs(args);
+
+        const oldSchemaHeaders = leftHeaders || headers;
+        const newSchemaHeaders = rightHeaders || headers;
 
         const oldSchema = await loaders.loadSchema(
           oldSchemaPointer,
           {
-            headers,
+            oldSchemaHeaders,
             token,
             method,
           },
@@ -142,7 +146,7 @@ export default createCommand<
         const newSchema = await loaders.loadSchema(
           newSchemaPointer,
           {
-            headers,
+            newSchemaHeaders,
             token,
             method,
           },

--- a/website/docs/essentials/diff.md
+++ b/website/docs/essentials/diff.md
@@ -113,3 +113,14 @@ module.exports = ({changes}) => {
 Now, you can use that module as a rule:
 
     graphql-inspector diff https://api.com/graphql schema.graphql --rule './custom-rule.js'
+
+
+### Passing different headers to multiple remote schemas
+
+If you want to do a diff between multiple remote schemas, each with different set of authentication headers, you can do it with `--left-header` and `--right-header` flags like so:
+
+`graphql-inspector diff http://your-schema-1/graphql http://your-schema-2/graphql --left-header 'Auth: Basic 123' --right-header 'Auth: Basic 345'`
+
+where `--left-header` will get passed to `http://your-schema-1/graphql` and `--right-header` will get passed to `http://your-schema-2/graphql`
+
+**Note:** `--left-header` and `--right-header` overrides the `--header` flags


### PR DESCRIPTION
## Description

Adds support for passing multiple headers when calling different remote schemas for a diff by adding flags `--leftheader` and `--rightheader` in addition to the already available `--header` flags.

Fixes https://github.com/kamilkisiela/graphql-inspector/issues/1909

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

![image](https://user-images.githubusercontent.com/1165845/115559018-ed1e1100-a2d0-11eb-8521-b387e1237e81.png)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules