### PR TITLE
Update docs for providing documents and schemas to programmatic API

### DIFF
--- a/website/docs/api/documents.md
+++ b/website/docs/api/documents.md
@@ -25,3 +25,27 @@ Given example above, Inspector will search every file that matches that pattern 
 Supported extensions: `.graphql`, `.graphqls` and `.gql`.
 
 > ⚠️ Remember to wrap a glob pattern with quotes: `"./src/app/**/*.graphql"` ⚠️
+
+## Programmatic API
+
+If you are using programmatic API, you might find `@graphql-tools/load` package useful for loading documents. Learn more [here](https://www.graphql-tools.com/docs/documents-loading).
+
+```js
+const { validate } = require('@graphql-inspector/core');
+const { loadDocuments } = require('@graphql-tools/load');
+const { GraphQLFileLoader } = require('@graphql-tools/graphql-file-loader');
+const graphql = require('graphql');
+
+const documents = loadDocuments('./src/**/*.graphql', {
+    loaders: [
+        new GraphQLFileLoader()
+    ]
+});
+
+// Convert documents to the format expected by "validate" function
+const sources = documents.map(doc => {
+    return new graphql.Source(graphql.print(doc.document), doc.location);
+});
+
+const invalidDocuments = validate(schema, sources);
+```

--- a/website/docs/api/schema.md
+++ b/website/docs/api/schema.md
@@ -71,3 +71,7 @@ For example, we want to fetch a .graphql file from master branch of [this sample
     github:kamilkisiela/graphql-inspector-example#master:./schema.graphql --token 'github-token-here'
 
 > GitHub Loader requires a GitHub token to be defined
+
+## Programmatic API
+
+If you are using programmatic API, you might find `@graphql-tools/load` package useful for loading schemas. Learn more [here](https://www.graphql-tools.com/docs/schema-loading).


### PR DESCRIPTION
## Description

Update documentation based on @Urigo's suggestion in  #1944 

- Add code example for providing documents to programmatic API
  (https://graphql-inspector.com/docs/api/documents)

- Add link to `graphql-tools` docs in providing schemas page
  (https://graphql-inspector.com/docs/api/schema)
