### PR TITLE
chore: typo fix for "validate" commands

### DIFF
--- a/packages/commands/validate/src/index.ts
+++ b/packages/commands/validate/src/index.ts
@@ -115,7 +115,7 @@ export default createCommand<
           demandOption: true,
         })
         .positional('documents', {
-          describe: 'Point to docuents',
+          describe: 'Point to documents',
           type: 'string',
           demandOption: true,
         })


### PR DESCRIPTION
## Description

Thought I was going to present this PR without an issue, since it's just a typo fix that's triggering my minor OCD 😆 

## Type of change

- [ x ] Documentation fix

## How Has This Been Tested?

- [ x ] Terminal test
Run `graphql-inspector validate --help` to get the updated information:
```shell
Positionals:
  schema     Point to a schema                               [string] [required]
  documents  Point to documents                               [string] [required]
```

## Checklist:

- [ x ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] My changes generate no new warnings

## Further comments

This is a super simple change but it's bothering me a little leaving it as it is.
