### PR TITLE
Make sure default argument values are printable

### DIFF
--- a/packages/core/__tests__/diff/argument.ts
+++ b/packages/core/__tests__/diff/argument.ts
@@ -1,0 +1,63 @@
+import {buildSchema} from 'graphql';
+
+import {findFirstChangeByPath} from '../../utils/testing';
+import {diff} from '../../src/index';
+import {CriticalityLevel} from '../../src/diff/changes/change';
+
+describe('argument', () => {
+  describe('default value', () => {
+    test('added', async () => {
+      const a = buildSchema(/* GraphQL */ `
+      input Foo {
+        a: String!
+      }
+        
+      type Dummy {
+        field(foo: Foo): String
+      }
+    `);
+      const b = buildSchema(/* GraphQL */ `
+      input Foo {
+        a: String!
+      }
+            
+      type Dummy {
+        field(foo: Foo = {a: "a"}): String
+      }
+    `);
+
+      const change = findFirstChangeByPath(await diff(a, b), 'Dummy.field.foo');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('FIELD_ARGUMENT_DEFAULT_CHANGED');
+      expect(change.message).toEqual('Default value \'[Object: null prototype] { a: \'a\' }\' was added to argument \'foo\' on field \'Dummy.field\'');
+    });
+
+    test('changed', async () => {
+      const a = buildSchema(/* GraphQL */ `
+      input Foo {
+        a: String!
+      }
+        
+      type Dummy {
+        field(foo: Foo = {a: "a"}): String
+      }
+    `);
+      const b = buildSchema(/* GraphQL */ `
+      input Foo {
+        a: String!
+      }
+            
+      type Dummy {
+        field(foo: Foo = {a: "new-value"}): String
+      }
+    `);
+
+      const change = findFirstChangeByPath(await diff(a, b), 'Dummy.field.foo');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('FIELD_ARGUMENT_DEFAULT_CHANGED');
+      expect(change.message).toEqual('Default value for argument \'foo\' on field \'Dummy.field\' changed from \'[Object: null prototype] { a: \'a\' }\' to \'[Object: null prototype] { a: \'new-value\' }\'');
+    });
+  });
+});

--- a/packages/core/src/diff/changes/argument.ts
+++ b/packages/core/src/diff/changes/argument.ts
@@ -7,6 +7,7 @@ import {
 
 import {Change, CriticalityLevel, ChangeType} from './change';
 import {safeChangeForInputValue} from '../../utils/graphql';
+import {safeString} from '../../utils/string';
 
 export function fieldArgumentDescriptionChanged(
   type: GraphQLObjectType | GraphQLInterfaceType,
@@ -39,8 +40,8 @@ export function fieldArgumentDefaultChanged(
     type: ChangeType.FieldArgumentDefaultChanged,
     message:
       typeof oldArg.defaultValue === 'undefined'
-        ? `Default value '${newArg.defaultValue}' was added to argument '${newArg.name}' on field '${type.name}.${field.name}'`
-        : `Default value for argument '${newArg.name}' on field '${type.name}.${field.name}' changed from '${oldArg.defaultValue}' to '${newArg.defaultValue}'`,
+        ? `Default value '${safeString(newArg.defaultValue)}' was added to argument '${newArg.name}' on field '${type.name}.${field.name}'`
+        : `Default value for argument '${newArg.name}' on field '${type.name}.${field.name}' changed from '${safeString(oldArg.defaultValue)}' to '${safeString(newArg.defaultValue)}'`,
     path: [type.name, field.name, oldArg.name].join('.'),
   };
 }


### PR DESCRIPTION
## Description

Make use of the util introduced in https://github.com/kamilkisiela/graphql-inspector/pull/1959 to prevent runtime exceptions during printing default value change.

Fixes #2016

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- n/a New feature (non-breaking change which adds functionality)
- n/a Breaking change (fix or feature that would cause existing functionality to not work as expected)
- n/a This change requires a documentation update

## How Has This Been Tested?

With unit test

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
