### PR TITLE
Make sure array of null prototype objects is printable

### DIFF
--- a/packages/core/__tests__/diff/argument.ts
+++ b/packages/core/__tests__/diff/argument.ts
@@ -31,7 +31,7 @@ describe('argument', () => {
       expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
       expect(change.type).toEqual('FIELD_ARGUMENT_DEFAULT_CHANGED');
       expect(change.message).toEqual(
-        "Default value '[Object: null prototype] { a: 'a' }' was added to argument 'foo' on field 'Dummy.field'",
+        "Default value '{ a: 'a' }' was added to argument 'foo' on field 'Dummy.field'",
       );
     });
 
@@ -60,7 +60,7 @@ describe('argument', () => {
       expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
       expect(change.type).toEqual('FIELD_ARGUMENT_DEFAULT_CHANGED');
       expect(change.message).toEqual(
-        "Default value for argument 'foo' on field 'Dummy.field' changed from '[Object: null prototype] { a: 'a' }' to '[Object: null prototype] { a: 'new-value' }'",
+        "Default value for argument 'foo' on field 'Dummy.field' changed from '{ a: 'a' }' to '{ a: 'new-value' }'",
       );
     });
   });

--- a/packages/core/__tests__/diff/schema.ts
+++ b/packages/core/__tests__/diff/schema.ts
@@ -450,7 +450,7 @@ test('array as default value in argument (different)', async () => {
   expect(changes[0]).toBeDefined();
   expect(changes[0].criticality.level).toEqual(CriticalityLevel.Dangerous);
   expect(changes[0].message).toEqual(
-    `Default value for argument 'b' on field 'MyInterface.a' changed from 'Hello' to 'Goodbye'`,
+    `Default value for argument 'b' on field 'MyInterface.a' changed from '[ 'Hello' ]' to '[ 'Goodbye' ]'`,
   );
   expect(changes[0].path).toEqual(`MyInterface.a.b`);
 });

--- a/packages/core/__tests__/utils/string.ts
+++ b/packages/core/__tests__/utils/string.ts
@@ -27,5 +27,5 @@ test('object', () => {
 test('array', () => {
   expect(safeString(['42', '42'])).toBe("[ '42', '42' ]");
   expect(safeString([{}])).toBe('[ {} ]');
-  expect(safeString([Object.create(null, { foo: { value: 42, enumerable: true } })])).toBe('[ [Object: null prototype] { foo: 42 } ]');
+  expect(safeString([Object.create(null, { foo: { value: 42, enumerable: true } })])).toBe('[ { foo: 42 } ]');
 });

--- a/packages/core/__tests__/utils/string.ts
+++ b/packages/core/__tests__/utils/string.ts
@@ -21,7 +21,7 @@ test('undefined', () => {
 
 test('object', () => {
   expect(safeString({})).toBe('{}');
-  expect(safeString(Object.create(null, { foo: { value: 42, enumerable: true } }))).toBe('[Object: null prototype] { foo: 42 }');
+  expect(safeString(Object.create(null, { foo: { value: 42, enumerable: true } }))).toBe('{ foo: 42 }');
 });
 
 test('array', () => {

--- a/packages/core/__tests__/utils/string.ts
+++ b/packages/core/__tests__/utils/string.ts
@@ -4,10 +4,10 @@ test('scalars', () => {
   expect(safeString(0)).toBe('0');
   expect(safeString(42)).toBe('42');
   expect(safeString(42.42)).toBe('42.42');
-  expect(safeString('42')).toBe('42');
-  expect(safeString('true')).toBe('true');
+  expect(safeString('42')).toBe("'42'");
+  expect(safeString('true')).toBe("'true'");
   expect(safeString(true)).toBe('true');
-  expect(safeString('false')).toBe('false');
+  expect(safeString('false')).toBe("'false'");
   expect(safeString(false)).toBe('false');
 });
 
@@ -17,4 +17,15 @@ test('null', () => {
 
 test('undefined', () => {
   expect(safeString(undefined)).toBe('undefined');
+});
+
+test('object', () => {
+  expect(safeString({})).toBe('{}');
+  expect(safeString(Object.create(null, { foo: { value: 42, enumerable: true } }))).toBe('[Object: null prototype] { foo: 42 }');
+});
+
+test('array', () => {
+  expect(safeString(['42', '42'])).toBe("[ '42', '42' ]");
+  expect(safeString([{}])).toBe('[ {} ]');
+  expect(safeString([Object.create(null, { foo: { value: 42, enumerable: true } })])).toBe('[ [Object: null prototype] { foo: 42 } ]');
 });

--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -79,8 +79,5 @@ function wordLetterPairs(str: string) {
 }
 
 export function safeString(obj: any) {
-  if (obj != null && typeof obj.toString === 'function') {
-    return `${obj}`;
-  }
   return inspect(obj);
 }

--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -79,5 +79,5 @@ function wordLetterPairs(str: string) {
 }
 
 export function safeString(obj: any) {
-  return inspect(obj).replace(/\[Object\: null prototype\]/g, '');
+  return inspect(obj).replace(/\[Object\: null prototype\] /g, '');
 }

--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -79,5 +79,5 @@ function wordLetterPairs(str: string) {
 }
 
 export function safeString(obj: any) {
-  return inspect(obj);
+  return inspect(obj).replace(/\[Object\: null prototype\]/g, '');
 }


### PR DESCRIPTION
## Description

Fixes #2016

Follow-up to https://github.com/kamilkisiela/graphql-inspector/pull/2017

Make sure that `safeString` function works with arrays too to prevent failures like 
![Screenshot 2021-10-07 at 08 27 56](https://user-images.githubusercontent.com/2437969/136331183-651a10ea-d4e0-4cc5-98f5-fb2c68e53060.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):



## How Has This Been Tested?

Unit tests

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
