### PR TITLE
fix: use "to" instead of "do" on annotations description on homepage

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -198,7 +198,7 @@ function Index() {
             <>
               <p>
                 GitHub offers <strong>in-code annotations</strong> and GraphQL
-                Inspector, both App and Action enables you do use them.
+                Inspector, both App and Action enables you to use them.
               </p>
               <p>
                 Nice and clean way to understand what have really changed and how


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

- [x] Website / Documentation

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
