### PR TITLE
fix equality for objects

### DIFF
--- a/packages/core/__tests__/utils/compare.ts
+++ b/packages/core/__tests__/utils/compare.ts
@@ -1,0 +1,37 @@
+import { isEqual, isNotEqual } from '../../src/utils/compare';
+
+test('isEqual', () => {
+  expect(isEqual('a', 'a')).toBe(true);
+  expect(isEqual('a', 'b')).toBe(false);
+
+  expect(isEqual(1, 1)).toBe(true);
+  expect(isEqual(1, 1.0)).toBe(true);
+
+  expect(isEqual(['a'], ['a'])).toBe(true);
+  expect(isEqual(['a'], ['A'])).toBe(false);
+  expect(isEqual(['a'], [''])).toBe(false);
+  expect(isEqual(['a'], ['aa'])).toBe(false);
+
+  expect(isEqual([{ test: 'a' }], [{ test: 'a' }])).toBe(true);
+  expect(isEqual([{ test: 'a' }], [{ test: 'b' }])).toBe(false);
+  expect(isEqual([{ test: { deep: 'a' } }], [{ test: { deep: 'a' } }])).toBe(
+    true,
+  );
+  expect(isEqual([{ test: { deep: 'a' } }], [{ test: { deep: 'b' } }])).toBe(
+    false,
+  );
+  expect(isEqual([{ test: { deep: 'a' } }], [{ test: { deeper: 'a' } }])).toBe(
+    false,
+  );
+  expect(
+    isEqual([{ test: { deep: 'a' } }], [{ test: { deep: 'a', twoKeys: 'b' } }]),
+  ).toBe(false);
+  expect(
+    isEqual([{ test: { deep: 'a', twoKeys: 'b' } }], [{ test: { deep: 'a' } }]),
+  ).toBe(false);
+});
+
+test('isNotEqual', () => {
+  expect(isNotEqual('a', 'a')).toBe(false);
+  expect(isNotEqual('a', 'b')).toBe(true);
+});

--- a/packages/core/__tests__/utils/compare.ts
+++ b/packages/core/__tests__/utils/compare.ts
@@ -1,4 +1,4 @@
-import { isEqual, isNotEqual } from '../../src/utils/compare';
+import { diffArrays, isEqual, isNotEqual } from '../../src/utils/compare';
 
 test('isEqual', () => {
   expect(isEqual('a', 'a')).toBe(true);
@@ -34,4 +34,16 @@ test('isEqual', () => {
 test('isNotEqual', () => {
   expect(isNotEqual('a', 'a')).toBe(false);
   expect(isNotEqual('a', 'b')).toBe(true);
+});
+
+test('diffArrays', () => {
+  expect(diffArrays(['a'], ['a'])).toEqual([]);
+  expect(diffArrays(['a'], ['a', 'b'])).toEqual([]);
+  expect(diffArrays(['a', 'b'], ['a'])).toEqual(['b']);
+  expect(
+    diffArrays(['a', { test: { deep: 'b' } }], [{ test: { deep: 'c' } }]),
+  ).toEqual(['a', { test: { deep: 'b' } }]);
+  expect(
+    diffArrays(['a', { test: { deep: 'b' } }], [{ test: { deep: 'b' } }]),
+  ).toEqual(['a']);
 });

--- a/packages/core/src/utils/compare.ts
+++ b/packages/core/src/utils/compare.ts
@@ -13,12 +13,30 @@ export function isEqual<T>(a: T, b: T): boolean {
     if (a.length !== b.length) return false;
 
     for (var index = 0; index < a.length; index++) {
-      if (a[index] !== b[index]) {
+      if (!isEqual(a[index], b[index])) {
         return false;
       }
     }
 
     return true;
+  }
+
+  if (typeof a === 'object' && typeof b === 'object') {
+    const aRecord = a as Record<string, unknown>;
+    const bRecord = b as Record<string, unknown>;
+
+    const aKeys: string[] = Object.keys(aRecord);
+    const bKeys: string[] = Object.keys(bRecord);
+
+    if (aKeys.length !== bKeys.length) return false;
+
+    for (const key of aKeys) {
+      if (!isEqual(aRecord[key], bRecord[key])) {
+        return false;
+      }
+    }
+    
+    return true
   }
 
   return a === b || (!a && !b);

--- a/packages/core/src/utils/compare.ts
+++ b/packages/core/src/utils/compare.ts
@@ -54,14 +54,7 @@ export function diffArrays<T>(
   a: T[] | readonly T[],
   b: T[] | readonly T[],
 ): T[] {
-  return a.filter((c) => !b.some((d) => d === c));
-}
-
-export function unionArrays<T>(
-  a: T[] | readonly T[],
-  b: T[] | readonly T[],
-): T[] {
-  return a.filter((c) => b.some((d) => d === c));
+  return a.filter((c) => !b.some((d) => isEqual(d, c)));
 }
 
 export function compareLists<T extends { name: string }>(


### PR DESCRIPTION
## Description

Modified equality logic to perform deep equality.  As in javascript
```javascript
{ test: 'a' } === { test: 'a' } 
```
returns false, which was making argument equality fail for lists of objects.

Fixes # (issue)
#2099 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests. If you run the same tests on master, they will fail.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
