### PR TITLE
Check 'ofType' of both sides when comparing non-null values

### DIFF
--- a/packages/core/__tests__/diff/input.ts
+++ b/packages/core/__tests__/diff/input.ts
@@ -266,6 +266,90 @@ describe('input', () => {
         "Input field 'c' was removed from input object type 'Foo'",
       );
     });
+
+    test('field made optional', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        input Foo {
+          a: String!
+          b: [String!]!
+          c: [String!]!
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        input Foo {
+          a: String
+          b: [String!]
+          c: [String]!
+        }
+      `);
+
+      const change = {
+        a: findFirstChangeByPath(await diff(a, b), 'Foo.a'),
+        b: findFirstChangeByPath(await diff(a, b), 'Foo.b'),
+        c: findFirstChangeByPath(await diff(a, b), 'Foo.c'),
+      };
+
+      // Scalar
+      expect(change.a.criticality.level).toEqual(CriticalityLevel.NonBreaking);
+      expect(change.a.type).toEqual('INPUT_FIELD_TYPE_CHANGED');
+      expect(change.a.message).toEqual(
+        "Input field 'Foo.a' changed type from 'String!' to 'String'",
+      );
+      // List
+      expect(change.b.criticality.level).toEqual(CriticalityLevel.NonBreaking);
+      expect(change.b.type).toEqual('INPUT_FIELD_TYPE_CHANGED');
+      expect(change.b.message).toEqual(
+        "Input field 'Foo.b' changed type from '[String!]!' to '[String!]'",
+        );
+      // List value
+      expect(change.c.criticality.level).toEqual(CriticalityLevel.NonBreaking);
+      expect(change.c.type).toEqual('INPUT_FIELD_TYPE_CHANGED');
+      expect(change.c.message).toEqual(
+        "Input field 'Foo.c' changed type from '[String!]!' to '[String]!'",
+        );
+    });
+
+    test('field made non-optional', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        input Foo {
+          a: String
+          b: [String!]
+          c: [String]!
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        input Foo {
+          a: String!
+          b: [String!]!
+          c: [String!]!
+        }
+      `);
+
+      const change = {
+        a: findFirstChangeByPath(await diff(a, b), 'Foo.a'),
+        b: findFirstChangeByPath(await diff(a, b), 'Foo.b'),
+        c: findFirstChangeByPath(await diff(a, b), 'Foo.c'),
+      };
+
+      // Scalar
+      expect(change.a.criticality.level).toEqual(CriticalityLevel.Breaking);
+      expect(change.a.type).toEqual('INPUT_FIELD_TYPE_CHANGED');
+      expect(change.a.message).toEqual(
+        "Input field 'Foo.a' changed type from 'String' to 'String!'",
+      );
+      // List
+      expect(change.b.criticality.level).toEqual(CriticalityLevel.Breaking);
+      expect(change.b.type).toEqual('INPUT_FIELD_TYPE_CHANGED');
+      expect(change.b.message).toEqual(
+        "Input field 'Foo.b' changed type from '[String!]' to '[String!]!'",
+        );
+      // List value
+      expect(change.c.criticality.level).toEqual(CriticalityLevel.Breaking);
+      expect(change.c.type).toEqual('INPUT_FIELD_TYPE_CHANGED');
+      expect(change.c.message).toEqual(
+        "Input field 'Foo.c' changed type from '[String]!' to '[String!]!'",
+        );
+    });
   });
 
   test('removal of a deprecated field', async () => {

--- a/packages/core/src/utils/graphql.ts
+++ b/packages/core/src/utils/graphql.ts
@@ -67,7 +67,7 @@ export function safeChangeForInputValue(
   }
 
   if (isNonNullType(oldType)) {
-    const ofType = isNonNullType(newType) ? newType : newType;
+    const ofType = isNonNullType(newType) ? newType.ofType : newType;
 
     return safeChangeForInputValue(oldType.ofType, ofType);
   }


### PR DESCRIPTION
## Description

This fixes #2107 . The bug is reproducible when making a list type optional in an input type:

**Original schema**
```
input Foo {
    a: String!
    b: [String!]!
}
```

**New schema**
```
input Foo {
    a: String
    b: [String!]
}
```

Would yield
```
✔  Input field Foo.a changed type from String! to String
✖  Input field Foo.b changed type from [String!]! to [String!]

error Detected 1 breaking change
```

This should not be considered a breaking change.

This happened because what looks like an erroneous ternary statement in `safeChangeForInputValue`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Run `core/__tests__/input.ts#test('field made optional')`
- [x] Run `core/__tests__/input.ts#test('field made non-optional')`

**Test Environment**:

- OS: MacOS Monterey 12.4
- NodeJS: 16.13.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A