### PR TITLE
Add extension fields to error objects thrown from findDeprecatedUsages

### DIFF
--- a/packages/core/__tests__/validate.ts
+++ b/packages/core/__tests__/validate.ts
@@ -519,7 +519,6 @@ describe('validate', () => {
     const results = validate(schema, [new Source(print(doc))]);
 
     expect(results.length).toEqual(1);
-    console.log(results[0].errors);
     expect(results[0].errors.length).toEqual(0);
     expect(results[0].deprecated.length).toEqual(1);
 

--- a/packages/core/__tests__/validate.ts
+++ b/packages/core/__tests__/validate.ts
@@ -528,7 +528,7 @@ describe('validate', () => {
     expect(deprecated.extensions).toMatchObject({
       type: 'enumValueDeprecation',
       namedType: 'Category',
-      enumVal: 'OFF_TOPIC',
+      enumValue: 'OFF_TOPIC',
     });
   });
 });

--- a/packages/core/__tests__/validate.ts
+++ b/packages/core/__tests__/validate.ts
@@ -422,7 +422,7 @@ describe('validate', () => {
     expect(deprecated.extensions).toMatchObject({
       type: 'argumentDeprecation',
       argument: 'query',
-      field: 'findPost',
+      fieldDef: 'findPost',
     });
   });
 

--- a/packages/core/__tests__/validate.ts
+++ b/packages/core/__tests__/validate.ts
@@ -39,7 +39,8 @@ describe('validate', () => {
     const deprecated = results[0].deprecated[0];
     expect(deprecated.message).toMatch(`The field 'Post.title' is deprecated. BECAUSE`);
     expect(deprecated.extensions).toMatchObject({
-      field: 'Post.title',
+      parentType: 'Post',
+      fieldDef: 'title',
     });
   });
 
@@ -469,7 +470,8 @@ describe('validate', () => {
     const deprecated = results[0].deprecated[0];
     expect(deprecated.message).toMatch(`The field 'Post.title' is deprecated. BECAUSE`);
     expect(deprecated.extensions).toMatchObject({
-      field: 'Post.title',
+      parentType: 'Post',
+      fieldDef: 'title',
     });
   });
 
@@ -521,7 +523,8 @@ describe('validate', () => {
     const deprecated = results[0].deprecated[0];
     expect(deprecated.message).toMatch(`The enum value 'Category.OFF_TOPIC' is deprecated. use OTHER`);
     expect(deprecated.extensions).toMatchObject({
-      enumValue: 'Category.OFF_TOPIC',
+      type: 'Category',
+      enumVal: 'OFF_TOPIC',
     });
   });
 });

--- a/packages/core/__tests__/validate.ts
+++ b/packages/core/__tests__/validate.ts
@@ -38,6 +38,9 @@ describe('validate', () => {
 
     const deprecated = results[0].deprecated[0];
     expect(deprecated.message).toMatch(`The field 'Post.title' is deprecated. BECAUSE`);
+    expect(deprecated.extensions).toMatchObject({
+      field: 'Post.title',
+    });
   });
 
   test('multiple fragments across multiple files with nested fragments (#36)', async () => {
@@ -414,6 +417,10 @@ describe('validate', () => {
     expect(deprecated.message).toMatch(
       `The argument 'query' of 'findPost' is deprecated. Please use 'searchQuery' instead.`
     );
+    expect(deprecated.extensions).toMatchObject({
+      argument: 'query',
+      field: 'findPost',
+    });
   });
 
   test('deprecated notice for field on fragment in different file', () => {
@@ -461,5 +468,8 @@ describe('validate', () => {
 
     const deprecated = results[0].deprecated[0];
     expect(deprecated.message).toMatch(`The field 'Post.title' is deprecated. BECAUSE`);
+    expect(deprecated.extensions).toMatchObject({
+      field: 'Post.title',
+    });
   });
 });

--- a/packages/core/__tests__/validate.ts
+++ b/packages/core/__tests__/validate.ts
@@ -39,6 +39,7 @@ describe('validate', () => {
     const deprecated = results[0].deprecated[0];
     expect(deprecated.message).toMatch(`The field 'Post.title' is deprecated. BECAUSE`);
     expect(deprecated.extensions).toMatchObject({
+      type: 'fieldDeprecation',
       parentType: 'Post',
       fieldDef: 'title',
     });
@@ -419,6 +420,7 @@ describe('validate', () => {
       `The argument 'query' of 'findPost' is deprecated. Please use 'searchQuery' instead.`
     );
     expect(deprecated.extensions).toMatchObject({
+      type: 'argumentDeprecation',
       argument: 'query',
       field: 'findPost',
     });
@@ -470,6 +472,7 @@ describe('validate', () => {
     const deprecated = results[0].deprecated[0];
     expect(deprecated.message).toMatch(`The field 'Post.title' is deprecated. BECAUSE`);
     expect(deprecated.extensions).toMatchObject({
+      type: 'fieldDeprecation',
       parentType: 'Post',
       fieldDef: 'title',
     });
@@ -523,7 +526,8 @@ describe('validate', () => {
     const deprecated = results[0].deprecated[0];
     expect(deprecated.message).toMatch(`The enum value 'Category.OFF_TOPIC' is deprecated. use OTHER`);
     expect(deprecated.extensions).toMatchObject({
-      type: 'Category',
+      type: 'enumValueDeprecation',
+      namedType: 'Category',
       enumVal: 'OFF_TOPIC',
     });
   });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,5 +3,11 @@ export { validate, InvalidDocument } from './validate';
 export { similar, SimilarMap } from './similar';
 export * from './coverage';
 export { Change, CriticalityLevel, Criticality, ChangeType } from './diff/changes/change';
-export { getTypePrefix } from './utils/graphql';
+export {
+  getTypePrefix,
+  DeprecationExtensions,
+  ArgumentDeprecationExtensions,
+  EnumValueDeprecationExtensions,
+  FieldDeprecationExtensions,
+} from './utils/graphql';
 export { Target, Rating, BestMatch } from './utils/string';

--- a/packages/core/src/utils/graphql.ts
+++ b/packages/core/src/utils/graphql.ts
@@ -142,7 +142,7 @@ export function findDeprecatedUsages(schema: GraphQLSchema, ast: DocumentNode): 
           if (reason) {
             const fieldDef = typeInfo.getFieldDef();
             if (fieldDef) {
-              const extensions: ArgumentDeprecationExtensions = { argument: argument?.name, field: fieldDef.name };
+              const extensions: ArgumentDeprecationExtensions = { argument: argument.name, field: fieldDef.name };
               errors.push(
                 new GraphQLError(
                   `The argument '${argument.name}' of '${fieldDef.name}' is deprecated. ${reason}`,

--- a/packages/core/src/utils/graphql.ts
+++ b/packages/core/src/utils/graphql.ts
@@ -142,17 +142,17 @@ export function findDeprecatedUsages(schema: GraphQLSchema, ast: DocumentNode): 
           const parentType = typeInfo.getParentType();
           if (parentType) {
             const reason = fieldDef.deprecationReason;
-            const field = `${parentType.name}.${fieldDef.name}`;
             errors.push(
               new GraphQLError(
-                `The field '${field}' is deprecated.${reason ? ' ' + reason : ''}`,
+                `The field '${parentType.name}.${fieldDef.name}' is deprecated.${reason ? ' ' + reason : ''}`,
                 [node],
                 undefined,
                 undefined,
                 undefined,
                 undefined,
                 {
-                  field,
+                  parentType: parentType.name,
+                  fieldDef: fieldDef.name,
                 }
               )
             );
@@ -165,17 +165,17 @@ export function findDeprecatedUsages(schema: GraphQLSchema, ast: DocumentNode): 
           const type = getNamedType(typeInfo.getInputType()!);
           if (type) {
             const reason = enumVal.deprecationReason;
-            const enumValue = `${type.name}.${enumVal.name}`;
             errors.push(
               new GraphQLError(
-                `The enum value '${enumValue}' is deprecated.${reason ? ' ' + reason : ''}`,
+                `The enum value '${type.name}.${enumVal.name}' is deprecated.${reason ? ' ' + reason : ''}`,
                 [node],
                 undefined,
                 undefined,
                 undefined,
                 undefined,
                 {
-                  enumValue,
+                  type: type.name,
+                  enumVal: enumVal.name,
                 }
               )
             );

--- a/packages/core/src/utils/graphql.ts
+++ b/packages/core/src/utils/graphql.ts
@@ -122,9 +122,15 @@ export function findDeprecatedUsages(schema: GraphQLSchema, ast: DocumentNode): 
             const fieldDef = typeInfo.getFieldDef();
             if (fieldDef) {
               errors.push(
-                new GraphQLError(`The argument '${argument?.name}' of '${fieldDef.name}' is deprecated. ${reason}`, [
-                  node,
-                ])
+                new GraphQLError(
+                  `The argument '${argument?.name}' of '${fieldDef.name}' is deprecated. ${reason}`,
+                  [node],
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  { argument: argument?.name, field: fieldDef.name }
+                )
               );
             }
           }
@@ -136,10 +142,18 @@ export function findDeprecatedUsages(schema: GraphQLSchema, ast: DocumentNode): 
           const parentType = typeInfo.getParentType();
           if (parentType) {
             const reason = fieldDef.deprecationReason;
+            const field = `${parentType.name}.${fieldDef.name}`;
             errors.push(
               new GraphQLError(
-                `The field '${parentType.name}.${fieldDef.name}' is deprecated.${reason ? ' ' + reason : ''}`,
-                [node]
+                `The field '${field}' is deprecated.${reason ? ' ' + reason : ''}`,
+                [node],
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                {
+                  field,
+                }
               )
             );
           }
@@ -151,10 +165,18 @@ export function findDeprecatedUsages(schema: GraphQLSchema, ast: DocumentNode): 
           const type = getNamedType(typeInfo.getInputType()!);
           if (type) {
             const reason = enumVal.deprecationReason;
+            const enumValue = `${type.name}.${enumVal.name}`;
             errors.push(
               new GraphQLError(
-                `The enum value '${type.name}.${enumVal.name}' is deprecated.${reason ? ' ' + reason : ''}`,
-                [node]
+                `The enum value '${enumValue}' is deprecated.${reason ? ' ' + reason : ''}`,
+                [node],
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                {
+                  enumValue,
+                }
               )
             );
           }

--- a/packages/core/src/utils/graphql.ts
+++ b/packages/core/src/utils/graphql.ts
@@ -128,7 +128,7 @@ export interface FieldDeprecationExtensions extends GraphQLErrorExtensions {
 export interface EnumValueDeprecationExtensions extends GraphQLErrorExtensions {
   type: 'enumValueDeprecation';
   namedType: string;
-  enumVal: string;
+  enumValue: string;
 }
 
 export function findDeprecatedUsages(schema: GraphQLSchema, ast: DocumentNode): Array<GraphQLError> {
@@ -191,19 +191,19 @@ export function findDeprecatedUsages(schema: GraphQLSchema, ast: DocumentNode): 
         }
       },
       EnumValue(node) {
-        const enumVal = typeInfo.getEnumValue();
-        if (enumVal && isDeprecated(enumVal)) {
+        const enumValue = typeInfo.getEnumValue();
+        if (enumValue && isDeprecated(enumValue)) {
           const namedType = getNamedType(typeInfo.getInputType()!);
           if (namedType) {
-            const reason = enumVal.deprecationReason;
+            const reason = enumValue.deprecationReason;
             const extensions: DeprecationExtensions = {
               type: 'enumValueDeprecation',
               namedType: namedType.name,
-              enumVal: enumVal.name,
+              enumValue: enumValue.name,
             };
             errors.push(
               new GraphQLError(
-                `The enum value '${namedType.name}.${enumVal.name}' is deprecated.${reason ? ' ' + reason : ''}`,
+                `The enum value '${namedType.name}.${enumValue.name}' is deprecated.${reason ? ' ' + reason : ''}`,
                 [node],
                 undefined,
                 undefined,

--- a/packages/core/src/utils/graphql.ts
+++ b/packages/core/src/utils/graphql.ts
@@ -116,7 +116,7 @@ export type DeprecationExtensions =
 export interface ArgumentDeprecationExtensions extends GraphQLErrorExtensions {
   type: 'argumentDeprecation';
   argument: string;
-  field: string;
+  fieldDef: string;
 }
 
 export interface FieldDeprecationExtensions extends GraphQLErrorExtensions {
@@ -148,7 +148,7 @@ export function findDeprecatedUsages(schema: GraphQLSchema, ast: DocumentNode): 
               const extensions: DeprecationExtensions = {
                 type: 'argumentDeprecation',
                 argument: argument.name,
-                field: fieldDef.name,
+                fieldDef: fieldDef.name,
               };
               errors.push(
                 new GraphQLError(


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Adds extra fields to the GraphQLError extensions objects for deprecation errors thrown from `findDeprecatedUsages`. This allows users to access the values in the error without needing to parse the error message. This also exports some types for users to use in their codebase as they will likely want to assert against them.

Fixes #2159

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as
appropriate

## How Has This Been Tested?
Unit Tests
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- `yarn test`

**Test Environment**:

- OS:
- `@graphql-inspector/...`:
- NodeJS: 16

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...
