### PR TITLE
Ignore TypeDescriptionsAdded & TypeDescriptionRemoved

### DIFF
--- a/packages/core/src/diff/changes/change.ts
+++ b/packages/core/src/diff/changes/change.ts
@@ -55,9 +55,7 @@ export enum ChangeType {
   TypeAdded = 'TYPE_ADDED',
   TypeKindChanged = 'TYPE_KIND_CHANGED',
   TypeDescriptionChanged = 'TYPE_DESCRIPTION_CHANGED',
-  // TODO
   TypeDescriptionRemoved = 'TYPE_DESCRIPTION_REMOVED',
-  // TODO
   TypeDescriptionAdded = 'TYPE_DESCRIPTION_ADDED',
   // Union
   UnionMemberRemoved = 'UNION_MEMBER_REMOVED',

--- a/packages/core/src/diff/object.ts
+++ b/packages/core/src/diff/object.ts
@@ -3,8 +3,9 @@ import { GraphQLObjectType } from 'graphql';
 import { objectTypeInterfaceAdded, objectTypeInterfaceRemoved } from './changes/object';
 import { fieldRemoved, fieldAdded } from './changes/field';
 import { changesInField } from './field';
-import { compareLists } from '../utils/compare';
+import { compareLists, isNotEqual, isVoid } from '../utils/compare';
 import { AddChange } from './schema';
+import { typeDescriptionAdded, typeDescriptionRemoved, typeDescriptionChanged } from './changes/type';
 
 export function changesInObject(oldType: GraphQLObjectType, newType: GraphQLObjectType, addChange: AddChange) {
   const oldInterfaces = oldType.getInterfaces();
@@ -12,6 +13,16 @@ export function changesInObject(oldType: GraphQLObjectType, newType: GraphQLObje
 
   const oldFields = oldType.getFields();
   const newFields = newType.getFields();
+  
+  if (isNotEqual(oldType.description, newType.description)) {
+    if (isVoid(oldType.description)) {
+      addChange(typeDescriptionAdded(newType));
+    } else if (isVoid(newType.description)) {
+      addChange(typeDescriptionRemoved(oldType));
+    } else {
+      addChange(typeDescriptionChanged(oldType, newType));
+    }
+  }
 
   compareLists(oldInterfaces, newInterfaces, {
     onAdded(i) {

--- a/packages/core/src/diff/rules/ignore-description-changes.ts
+++ b/packages/core/src/diff/rules/ignore-description-changes.ts
@@ -12,6 +12,8 @@ const descriptionChangeTypes: ChangeType[] = [
   ChangeType.InputFieldDescriptionAdded,
   ChangeType.InputFieldDescriptionRemoved,
   ChangeType.InputFieldDescriptionChanged,
+  ChangeType.TypeDescriptionAdded,
+  ChangeType.TypeDescriptionRemoved,
   ChangeType.TypeDescriptionChanged,
 ];
 


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Before, `diff --rule ignoreDescriptionChanges` does not worked properly: TypeDescriptionRemoved, TypeDescriptionAdded is not called.

Fixes # https://github.com/kamilkisiela/graphql-inspector/issues/2161

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- [x] yarn jest
- [ ] Test B

**Test Environment**:

- OS: MacOS
- `@graphql-inspector/cli`: 3.3.0
- NodeJS: 16.15.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

