### PR TITLE
feat: validate and audit max alias count, max directive count, query complexity and token count

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -106,6 +106,18 @@ const invalid: InvalidDocument[] = validate(documentsGlob, schema)
 
 ![Validate](https://raw.githubusercontent.com/kamilkisiela/graphql-inspector/master/assets/validate.jpg)
 
+### Audit documents
+
+Audit your documents for useful metrics such as query depth, directive count and alias count.
+
+**CLI:**
+
+    $ graphql-inspector audit DOCUMENTS
+
+**API:**
+
+Not available
+
 ### Serve faked GraphQL API
 
 Serves a GraphQL server with faked data and GraphQL Playground

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -118,6 +118,30 @@ Audit your documents for useful metrics such as query depth, directive count and
 
 Not available
 
+```
+$ yarn graphql-inspector audit "packages/**/*.graphql|packages/**/*.ts(x)"
+
+Maximum depth is 16
+Maximum alias amount is 3
+Maximum directive amount is 6
+```
+
+```
+$ yarn graphql-inspector audit "packages/**/*.graphql|packages/**/*.ts(x)" --detail
+
+┌────────────────┬───────┬─────────┬────────────┐
+│ Operation Name │ Depth │ Aliases │ Directives │
+├────────────────┼───────┼─────────┼────────────┤
+│ getFoo         │ 1     │ 2       │ 6          │
+├────────────────┼───────┼─────────┼────────────┤
+│ getBar         │ 16    │ 3       │ 0          │
+└────────────────┴───────┴─────────┴────────────┘
+
+Maximum depth is 16
+Maximum alias amount is 3
+Maximum directive amount is 6
+```
+
 ### Serve faked GraphQL API
 
 Serves a GraphQL server with faked data and GraphQL Playground

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -76,6 +76,7 @@
     "@graphql-inspector/similar-command": "0.0.0-PLACEHOLDER",
     "@graphql-inspector/url-loader": "0.0.0-PLACEHOLDER",
     "@graphql-inspector/validate-command": "0.0.0-PLACEHOLDER",
+    "@graphql-inspector/audit-command": "0.0.0-PLACEHOLDER",
     "tslib": "^2.0.0",
     "yargs": "17.2.1"
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,7 +5,7 @@ import yargs, { Argv } from 'yargs';
 async function main() {
   const config = {
     loaders: ['code', 'git', 'github', 'graphql', 'json', 'url'],
-    commands: ['docs', 'serve', 'diff', 'validate', 'coverage', 'introspect', 'similar'],
+    commands: ['docs', 'serve', 'diff', 'validate', 'coverage', 'introspect', 'similar', 'audit'],
   };
   const loaders = useLoaders(config);
   const commands = useCommands({ config, loaders });

--- a/packages/commands/audit/package.json
+++ b/packages/commands/audit/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@graphql-inspector/audit-command",
+  "version": "0.0.0-PLACEHOLDER",
+  "description": "Audit Documents in GraphQL Inspector",
+  "keywords": [
+    "graphql",
+    "graphql-inspector",
+    "graphql-inspector-command",
+    "tools"
+  ],
+  "sideEffects": false,
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": {
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs"
+    }
+  },
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "author": {
+    "name": "Laurin Quast",
+    "email": "laurinquast@googlemail.com",
+    "url": "https://github.com/kamilkisiela"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "kamilkisiela/graphql-inspector",
+    "directory": "packages/commands/audit"
+  },
+  "peerDependencies": {
+    "graphql": "^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+  },
+  "dependencies": {
+    "@graphql-inspector/commands": "0.0.0-PLACEHOLDER",
+    "@graphql-inspector/core": "0.0.0-PLACEHOLDER",
+    "@graphql-inspector/logger": "0.0.0-PLACEHOLDER",
+    "tslib": "^2.0.0",
+    "cli-table3": "0.6.2"
+  },
+  "scripts": {
+    "prepack": "bob prepack"
+  }
+}

--- a/packages/commands/audit/src/index.ts
+++ b/packages/commands/audit/src/index.ts
@@ -1,5 +1,6 @@
 import { createCommand, GlobalArgs } from '@graphql-inspector/commands';
-import { countAliases, countDepth, countDirectives } from '@graphql-inspector/core';
+import { countAliases, countDepth, countDirectives, calculateOperationComplexity } from '@graphql-inspector/core';
+import type { CalculateOperationComplexityConfig } from '@graphql-inspector/core';
 import { Source as DocumentSource } from '@graphql-tools/utils';
 import { FragmentDefinitionNode, OperationDefinitionNode } from 'graphql';
 import { Logger, chalk } from '@graphql-inspector/logger';
@@ -10,6 +11,9 @@ export default createCommand<
   {
     documents: string;
     detail: boolean;
+    complexityScalarCost: number;
+    complexityObjectCost: number;
+    complexityDepthCostFactor: number;
   } & GlobalArgs
 >(api => {
   return {
@@ -30,6 +34,21 @@ export default createCommand<
             type: 'boolean',
             default: false,
           },
+          complexityScalarCost: {
+            describe: 'The cost per scalar for calculating the complexity score.',
+            type: 'number',
+            default: 1,
+          },
+          complexityObjectCost: {
+            describe: 'The cost per object for calculating the complexity score.',
+            type: 'number',
+            default: 2,
+          },
+          complexityDepthCostFactor: {
+            describe: 'The cost factor per introduced depth level for calculating the complexity score.',
+            type: 'number',
+            default: 1.5,
+          },
         });
     },
     async handler(args) {
@@ -39,12 +58,22 @@ export default createCommand<
         ignore,
       });
 
-      return handler({ documents, detail: args.detail });
+      const complexityConfig: CalculateOperationComplexityConfig = {
+        scalarCost: args.complexityScalarCost,
+        objectCost: args.complexityObjectCost,
+        depthCostFactor: args.complexityDepthCostFactor,
+      };
+
+      return handler({ documents, detail: args.detail, complexityConfig });
     },
   };
 });
 
-export function handler(args: { documents: DocumentSource[]; detail: boolean }) {
+export function handler(args: {
+  documents: DocumentSource[];
+  detail: boolean;
+  complexityConfig: CalculateOperationComplexityConfig;
+}) {
   const fragments = new Map<string, FragmentDefinitionNode>();
   const operations = new Map<string, OperationDefinitionNode>();
 
@@ -67,22 +96,25 @@ export function handler(args: { documents: DocumentSource[]; detail: boolean }) 
   let maxDepth = 0;
   let maxAliases = 0;
   let maxDirectives = 0;
+  let maxComplexity = 0;
 
-  const results: Array<[name: string, depth: number, aliases: number, directives: number]> = [];
+  const results: Array<[name: string, depth: number, aliases: number, directives: number, complexity: number]> = [];
 
   for (const [name, operation] of operations.entries()) {
     const depth = countDepth(operation, 0, getFragmentReference);
     const aliases = countAliases(operation, getFragmentReference);
     const directives = countDirectives(operation, getFragmentReference);
-    results.push([name, depth, aliases, directives]);
+    const complexity = calculateOperationComplexity(operation, args.complexityConfig, getFragmentReference);
+    results.push([name, depth, aliases, directives, complexity]);
     maxDepth = Math.max(maxDepth, depth);
     maxAliases = Math.max(maxAliases, aliases);
     maxDirectives = Math.max(maxDirectives, directives);
+    maxComplexity = Math.max(maxComplexity, complexity);
   }
 
   if (args.detail) {
     const table = new Table({
-      head: ['Operation Name', 'Depth', 'Aliases', 'Directives'],
+      head: ['Operation Name', 'Depth', 'Aliases', 'Directives', 'Complexity Score'],
     });
     table.push(...results);
     Logger.log(table.toString());
@@ -91,4 +123,5 @@ export function handler(args: { documents: DocumentSource[]; detail: boolean }) 
   Logger.log(`Maximum depth is ${chalk.bold(maxDepth)}`);
   Logger.log(`Maximum alias amount is ${chalk.bold(maxAliases)}`);
   Logger.log(`Maximum directive amount is ${chalk.bold(maxDirectives)}`);
+  Logger.log(`Maximum complexity score is ${chalk.bold(maxComplexity)}`);
 }

--- a/packages/commands/audit/src/index.ts
+++ b/packages/commands/audit/src/index.ts
@@ -1,0 +1,94 @@
+import { createCommand, GlobalArgs } from '@graphql-inspector/commands';
+import { countAliases, countDepth, countDirectives } from '@graphql-inspector/core';
+import { Source as DocumentSource } from '@graphql-tools/utils';
+import { FragmentDefinitionNode, OperationDefinitionNode } from 'graphql';
+import { Logger, chalk } from '@graphql-inspector/logger';
+import Table from 'cli-table3';
+
+export default createCommand<
+  {},
+  {
+    documents: string;
+    detail: boolean;
+  } & GlobalArgs
+>(api => {
+  return {
+    command: 'audit <documents>',
+    describe:
+      'Audit Fragments and Operations for a better understanding of the depth, alias count, and directive count.',
+    builder(yargs) {
+      return yargs
+        .positional('documents', {
+          describe: 'Point to some documents',
+          type: 'string',
+          demandOption: true,
+        })
+        .options({
+          detail: {
+            alias: 'd',
+            describe: 'Print an overview of all operations and their audit breakdown.',
+            type: 'boolean',
+            default: false,
+          },
+        });
+    },
+    async handler(args) {
+      const { loaders } = api;
+      const ignore = args.ignore || [];
+      const documents = await loaders.loadDocuments(args.documents, {
+        ignore,
+      });
+
+      return handler({ documents, detail: args.detail });
+    },
+  };
+});
+
+export function handler(args: { documents: DocumentSource[]; detail: boolean }) {
+  const fragments = new Map<string, FragmentDefinitionNode>();
+  const operations = new Map<string, OperationDefinitionNode>();
+
+  const getFragmentReference = (fragmentName: string) => fragments.get(fragmentName);
+
+  for (const record of args.documents) {
+    if (record.document) {
+      for (const definition of record.document.definitions) {
+        if (definition.kind === 'FragmentDefinition') {
+          fragments.set(definition.name.value, definition);
+        } else if (definition.kind === 'OperationDefinition') {
+          if (definition.name) {
+            operations.set(definition.name.value, definition);
+          }
+        }
+      }
+    }
+  }
+
+  let maxDepth = 0;
+  let maxAliases = 0;
+  let maxDirectives = 0;
+
+  const results: Array<[name: string, depth: number, aliases: number, directives: number]> = [];
+
+  for (const [name, operation] of operations.entries()) {
+    const depth = countDepth(operation, 0, getFragmentReference);
+    const aliases = countAliases(operation, getFragmentReference);
+    const directives = countDirectives(operation, getFragmentReference);
+    results.push([name, depth, aliases, directives]);
+    maxDepth = Math.max(maxDepth, depth);
+    maxAliases = Math.max(maxAliases, aliases);
+    maxDirectives = Math.max(maxDirectives, directives);
+  }
+
+  if (args.detail) {
+    const table = new Table({
+      head: ['Operation Name', 'Depth', 'Aliases', 'Directives'],
+    });
+    table.push(...results);
+    Logger.log(table.toString());
+  }
+
+  Logger.log(`Maximum depth is ${chalk.bold(maxDepth)}`);
+  Logger.log(`Maximum alias amount is ${chalk.bold(maxAliases)}`);
+  Logger.log(`Maximum directive amount is ${chalk.bold(maxDirectives)}`);
+}

--- a/packages/commands/validate/src/index.ts
+++ b/packages/commands/validate/src/index.ts
@@ -13,6 +13,8 @@ export function handler({
   documents,
   strictFragments,
   maxDepth,
+  maxDirectiveCount,
+  maxAliasCount,
   apollo,
   keepClientFields,
   failOnDeprecated,
@@ -29,6 +31,8 @@ export function handler({
   apollo: boolean;
   keepClientFields: boolean;
   maxDepth?: number;
+  maxDirectiveCount?: number;
+  maxAliasCount?: number;
   filter?: string[];
   onlyErrors?: boolean;
   relativePaths?: boolean;
@@ -41,6 +45,8 @@ export function handler({
     {
       strictFragments,
       maxDepth,
+      maxAliasCount,
+      maxDirectiveCount,
       apollo,
       keepClientFields,
     }
@@ -174,6 +180,14 @@ export default createCommand<
           },
           maxDepth: {
             describe: 'Fail on deep operations',
+            type: 'number',
+          },
+          maxAliasCount: {
+            describe: 'Fail on operations with too many aliases',
+            type: 'number',
+          },
+          maxDirectiveCount: {
+            describe: 'Fail on operations with too many directives',
             type: 'number',
           },
           apollo: {

--- a/packages/commands/validate/src/index.ts
+++ b/packages/commands/validate/src/index.ts
@@ -141,6 +141,8 @@ export default createCommand<
     apollo: boolean;
     keepClientFields: boolean;
     maxDepth?: number;
+    maxAliasCount?: number;
+    maxDirectiveCount?: number;
     filter?: string[];
     onlyErrors?: boolean;
     relativePaths?: boolean;
@@ -237,7 +239,9 @@ export default createCommand<
       const aws = args.aws || false;
       const apolloFederation = args.federation || false;
       const method = args.method?.toUpperCase() || 'POST';
-      const maxDepth = args.maxDepth || undefined;
+      const maxDepth = args.maxDepth != null ? args.maxDepth : undefined;
+      const maxAliasCount = args.maxAliasCount != null ? args.maxAliasCount : undefined;
+      const maxDirectiveCount = args.maxDirectiveCount != null ? args.maxDirectiveCount: undefined;
       const strictFragments = !args.noStrictFragments;
       const keepClientFields = args.keepClientFields || false;
       const failOnDeprecated = args.deprecated;
@@ -266,6 +270,8 @@ export default createCommand<
         documents,
         apollo,
         maxDepth,
+        maxAliasCount,
+        maxDirectiveCount,
         strictFragments,
         keepClientFields,
         failOnDeprecated,

--- a/packages/commands/validate/src/index.ts
+++ b/packages/commands/validate/src/index.ts
@@ -15,6 +15,7 @@ export function handler({
   maxDepth,
   maxDirectiveCount,
   maxAliasCount,
+  maxTokenCount,
   apollo,
   keepClientFields,
   failOnDeprecated,
@@ -33,6 +34,7 @@ export function handler({
   maxDepth?: number;
   maxDirectiveCount?: number;
   maxAliasCount?: number;
+  maxTokenCount?: number;
   filter?: string[];
   onlyErrors?: boolean;
   relativePaths?: boolean;
@@ -47,6 +49,7 @@ export function handler({
       maxDepth,
       maxAliasCount,
       maxDirectiveCount,
+      maxTokenCount,
       apollo,
       keepClientFields,
     }
@@ -143,6 +146,7 @@ export default createCommand<
     maxDepth?: number;
     maxAliasCount?: number;
     maxDirectiveCount?: number;
+    maxTokenCount?: number;
     filter?: string[];
     onlyErrors?: boolean;
     relativePaths?: boolean;
@@ -190,6 +194,10 @@ export default createCommand<
           },
           maxDirectiveCount: {
             describe: 'Fail on operations with too many directives',
+            type: 'number',
+          },
+          maxTokenCount: {
+            describe: 'Fail on operations with too many tokens',
             type: 'number',
           },
           apollo: {
@@ -241,7 +249,8 @@ export default createCommand<
       const method = args.method?.toUpperCase() || 'POST';
       const maxDepth = args.maxDepth != null ? args.maxDepth : undefined;
       const maxAliasCount = args.maxAliasCount != null ? args.maxAliasCount : undefined;
-      const maxDirectiveCount = args.maxDirectiveCount != null ? args.maxDirectiveCount: undefined;
+      const maxDirectiveCount = args.maxDirectiveCount != null ? args.maxDirectiveCount : undefined;
+      const maxTokenCount = args.maxTokenCount != null ? args.maxTokenCount : undefined;
       const strictFragments = !args.noStrictFragments;
       const keepClientFields = args.keepClientFields || false;
       const failOnDeprecated = args.deprecated;
@@ -272,6 +281,7 @@ export default createCommand<
         maxDepth,
         maxAliasCount,
         maxDirectiveCount,
+        maxTokenCount,
         strictFragments,
         keepClientFields,
         failOnDeprecated,

--- a/packages/core/__tests__/validate/token-count.ts
+++ b/packages/core/__tests__/validate/token-count.ts
@@ -1,0 +1,37 @@
+import { calculateTokenCount } from '../../src/validate/token-count';
+
+describe('calculateDepth', () => {
+  it('calculate easy operation', () => {
+    const source = `{brrt}`;
+    const count = calculateTokenCount({
+      source,
+      getReferencedFragmentSource: () => {
+        throw new Error('noop');
+      },
+    });
+    expect(count).toEqual(3);
+  });
+  it('calculate another easy operation', () => {
+    const source = `query{brrt}`;
+    const count = calculateTokenCount({
+      source,
+      getReferencedFragmentSource: () => {
+        throw new Error('noop');
+      },
+    });
+    expect(count).toEqual(4);
+  });
+  it('calculate with external fragment', () => {
+    const source = `query{...Swag}`;
+    const count = calculateTokenCount({
+      source,
+      getReferencedFragmentSource: name => {
+        if (name === 'Swag') {
+          return `fragment Swag on Query{brrt}`;
+        }
+        throw new Error('noop');
+      },
+    });
+    expect(count).toEqual(12);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,3 +5,6 @@ export * from './coverage';
 export { Change, CriticalityLevel, Criticality, ChangeType } from './diff/changes/change';
 export { getTypePrefix } from './utils/graphql';
 export { Target, Rating, BestMatch } from './utils/string';
+export { countAliases } from './validate/alias-count';
+export { countDirectives } from './validate/directive-count';
+export { countDepth } from './validate/query-depth';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,3 +9,4 @@ export { countAliases } from './validate/alias-count';
 export { countDirectives } from './validate/directive-count';
 export { countDepth } from './validate/query-depth';
 export { calculateOperationComplexity, CalculateOperationComplexityConfig } from './validate/complexity';
+export { calculateTokenCount } from './validate/token-count';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,3 +8,4 @@ export { Target, Rating, BestMatch } from './utils/string';
 export { countAliases } from './validate/alias-count';
 export { countDirectives } from './validate/directive-count';
 export { countDepth } from './validate/query-depth';
+export { calculateOperationComplexity, CalculateOperationComplexityConfig } from './validate/complexity';

--- a/packages/core/src/validate/alias-count.ts
+++ b/packages/core/src/validate/alias-count.ts
@@ -39,7 +39,7 @@ export function validateAliasCount({
   }
 }
 
-function countAliases(
+export function countAliases(
   node: FieldNode | FragmentDefinitionNode | InlineFragmentNode | OperationDefinitionNode | FragmentSpreadNode,
   getFragmentByName: (fragmentName: string) => FragmentDefinitionNode | undefined
 ) {

--- a/packages/core/src/validate/alias-count.ts
+++ b/packages/core/src/validate/alias-count.ts
@@ -1,0 +1,61 @@
+import { DepGraph } from 'dependency-graph';
+import type {
+  DocumentNode,
+  FragmentDefinitionNode,
+  Source,
+  FieldNode,
+  InlineFragmentNode,
+  OperationDefinitionNode,
+  FragmentSpreadNode,
+} from 'graphql';
+import { GraphQLError, Kind } from 'graphql';
+
+export function validateAliasCount({
+  source,
+  doc,
+  maxAliasCount,
+  fragmentGraph,
+}: {
+  source: Source;
+  doc: DocumentNode;
+  maxAliasCount: number;
+  fragmentGraph: DepGraph<FragmentDefinitionNode>;
+}): GraphQLError | void {
+  const getFragmentByFragmentName = (fragmentName: string) => fragmentGraph.getNodeData(fragmentName);
+
+  for (const definition of doc.definitions) {
+    if (definition.kind !== Kind.OPERATION_DEFINITION) {
+      continue;
+    }
+    const aliasCount = countAliases(definition, getFragmentByFragmentName);
+    if (aliasCount > maxAliasCount) {
+      return new GraphQLError(
+        `Too many aliases (${aliasCount}). Maximum allowed is ${maxAliasCount}`,
+        [definition],
+        source,
+        definition.loc && definition.loc.start ? [definition.loc.start] : undefined
+      );
+    }
+  }
+}
+
+function countAliases(
+  node: FieldNode | FragmentDefinitionNode | InlineFragmentNode | OperationDefinitionNode | FragmentSpreadNode,
+  getFragmentByName: (fragmentName: string) => FragmentDefinitionNode | undefined
+) {
+  let aliases = 0;
+  if ('alias' in node && node.alias) {
+    ++aliases;
+  }
+  if ('selectionSet' in node && node.selectionSet) {
+    for (let child of node.selectionSet.selections) {
+      aliases += countAliases(child, getFragmentByName);
+    }
+  } else if (node.kind === Kind.FRAGMENT_SPREAD) {
+    const fragmentNode = getFragmentByName(node.name.value);
+    if (fragmentNode) {
+      aliases += countAliases(fragmentNode, getFragmentByName);
+    }
+  }
+  return aliases;
+}

--- a/packages/core/src/validate/complexity.ts
+++ b/packages/core/src/validate/complexity.ts
@@ -1,0 +1,72 @@
+import { DepGraph } from 'dependency-graph';
+import type {
+  DocumentNode,
+  FragmentDefinitionNode,
+  Source,
+  FieldNode,
+  InlineFragmentNode,
+  OperationDefinitionNode,
+  FragmentSpreadNode,
+} from 'graphql';
+import { GraphQLError, Kind } from 'graphql';
+
+export type CalculateOperationComplexityConfig = {
+  scalarCost: number;
+  objectCost: number;
+  depthCostFactor: number;
+};
+
+export function validateComplexity({
+  source,
+  doc,
+  maxComplexityScore,
+  config,
+  fragmentGraph,
+}: {
+  source: Source;
+  doc: DocumentNode;
+  maxComplexityScore: number;
+  config: CalculateOperationComplexityConfig;
+  fragmentGraph: DepGraph<FragmentDefinitionNode>;
+}): GraphQLError | void {
+  const getFragmentByFragmentName = (fragmentName: string) => fragmentGraph.getNodeData(fragmentName);
+
+  for (const definition of doc.definitions) {
+    if (definition.kind !== Kind.OPERATION_DEFINITION) {
+      continue;
+    }
+    const complexityScore = calculateOperationComplexity(definition, config, getFragmentByFragmentName);
+    if (complexityScore > maxComplexityScore) {
+      return new GraphQLError(
+        `Too high complexity score (${complexityScore}). Maximum allowed is ${maxComplexityScore}`,
+        [definition],
+        source,
+        definition.loc && definition.loc.start ? [definition.loc.start] : undefined
+      );
+    }
+  }
+}
+
+export function calculateOperationComplexity(
+  node: FieldNode | FragmentDefinitionNode | InlineFragmentNode | OperationDefinitionNode | FragmentSpreadNode,
+  config: CalculateOperationComplexityConfig,
+  getFragmentByName: (fragmentName: string) => FragmentDefinitionNode | undefined,
+  depth: number = 0
+) {
+  let cost = config.scalarCost;
+  if ('selectionSet' in node && node.selectionSet) {
+    cost = config.objectCost;
+    for (let child of node.selectionSet.selections) {
+      cost += config.depthCostFactor * calculateOperationComplexity(child, config, getFragmentByName, depth + 1);
+    }
+  }
+
+  if (node.kind == Kind.FRAGMENT_SPREAD) {
+    const fragment = getFragmentByName(node.name.value);
+    if (fragment) {
+      cost += config.depthCostFactor * calculateOperationComplexity(fragment, config, getFragmentByName, depth + 1);
+    }
+  }
+
+  return cost;
+}

--- a/packages/core/src/validate/directive-count.ts
+++ b/packages/core/src/validate/directive-count.ts
@@ -39,7 +39,7 @@ export function validateDirectiveCount({
   }
 }
 
-function countDirectives(
+export function countDirectives(
   node: FieldNode | FragmentDefinitionNode | InlineFragmentNode | OperationDefinitionNode | FragmentSpreadNode,
   getFragmentByName: (fragmentName: string) => FragmentDefinitionNode | undefined
 ) {

--- a/packages/core/src/validate/directive-count.ts
+++ b/packages/core/src/validate/directive-count.ts
@@ -1,0 +1,62 @@
+import { DepGraph } from 'dependency-graph';
+import type {
+  DocumentNode,
+  FragmentDefinitionNode,
+  Source,
+  FieldNode,
+  InlineFragmentNode,
+  OperationDefinitionNode,
+  FragmentSpreadNode,
+} from 'graphql';
+import { GraphQLError, Kind } from 'graphql';
+
+export function validateDirectiveCount({
+  source,
+  doc,
+  maxDirectiveCount,
+  fragmentGraph,
+}: {
+  source: Source;
+  doc: DocumentNode;
+  maxDirectiveCount: number;
+  fragmentGraph: DepGraph<FragmentDefinitionNode>;
+}): GraphQLError | void {
+  const getFragmentByFragmentName = (fragmentName: string) => fragmentGraph.getNodeData(fragmentName);
+
+  for (const definition of doc.definitions) {
+    if (definition.kind !== Kind.OPERATION_DEFINITION) {
+      continue;
+    }
+    const directiveCount = countDirectives(definition, getFragmentByFragmentName);
+    if (directiveCount > maxDirectiveCount) {
+      return new GraphQLError(
+        `Too many directives (${directiveCount}). Maximum allowed is ${maxDirectiveCount}`,
+        [definition],
+        source,
+        definition.loc && definition.loc.start ? [definition.loc.start] : undefined
+      );
+    }
+  }
+}
+
+function countDirectives(
+  node: FieldNode | FragmentDefinitionNode | InlineFragmentNode | OperationDefinitionNode | FragmentSpreadNode,
+  getFragmentByName: (fragmentName: string) => FragmentDefinitionNode | undefined
+) {
+  let directives = 0;
+  if (node.directives) {
+    directives += node.directives.length;
+  }
+  if ('selectionSet' in node && node.selectionSet) {
+    for (let child of node.selectionSet.selections) {
+      directives += countDirectives(child, getFragmentByName);
+    }
+  }
+  if (node.kind == Kind.FRAGMENT_SPREAD) {
+    const fragment = getFragmentByName(node.name.value);
+    if (fragment) {
+      directives += countDirectives(fragment, getFragmentByName);
+    }
+  }
+  return directives;
+}

--- a/packages/core/src/validate/index.ts
+++ b/packages/core/src/validate/index.ts
@@ -14,6 +14,8 @@ import { readDocument } from '../ast/document';
 import { findDeprecatedUsages } from '../utils/graphql';
 import { validateQueryDepth } from './query-depth';
 import { transformSchemaWithApollo, transformDocumentWithApollo } from '../utils/apollo';
+import { validateAliasCount } from './alias-count';
+import { validateDirectiveCount } from './directive-count';
 
 export interface InvalidDocument {
   source: Source;
@@ -43,10 +45,20 @@ export interface ValidateOptions {
    */
   apollo?: boolean;
   /**
-   * Fails when operation depth exceeds maximum depth
-   * @default false
+   * Fails when operation depth exceeds maximum depth (including the referenced fragments).
+   * @default Infinity
    */
   maxDepth?: number;
+  /**
+   * Fails when alias count exceeds maximum count (including the referenced fragments).
+   * @default Infinity
+   */
+  maxAliasCount?: number;
+  /**
+   * Fails when the directive count exceeds maximum count for a single operation (including the referenced fragments).
+   * @default Infinity
+   */
+  maxDirectiveCount?: number;
 }
 
 export function validate(schema: GraphQLSchema, sources: Source[], options?: ValidateOptions): InvalidDocument[] {
@@ -123,6 +135,32 @@ export function validate(schema: GraphQLSchema, sources: Source[], options?: Val
 
         if (depthError) {
           errors.push(depthError);
+        }
+      }
+
+      if (config.maxAliasCount) {
+        const aliasError = validateAliasCount({
+          source: doc.source,
+          doc: transformedDoc,
+          maxAliasCount: config.maxAliasCount,
+          fragmentGraph: graph,
+        });
+
+        if (aliasError) {
+          errors.push(aliasError);
+        }
+      }
+
+      if (config.maxDirectiveCount) {
+        const directiveError = validateDirectiveCount({
+          source: doc.source,
+          doc: transformedDoc,
+          maxDirectiveCount: config.maxDirectiveCount,
+          fragmentGraph: graph,
+        });
+
+        if (directiveError) {
+          errors.push(directiveError);
         }
       }
 

--- a/packages/core/src/validate/token-count.ts
+++ b/packages/core/src/validate/token-count.ts
@@ -1,0 +1,53 @@
+import { TokenKind, visit } from 'graphql';
+import type { ParseOptions, Source } from 'graphql';
+import { Parser } from 'graphql/language/parser';
+
+class ParserWithLexer extends Parser {
+  private __tokenCount: number = 0;
+
+  get tokenCount() {
+    return this.__tokenCount;
+  }
+
+  constructor(source: string | Source, options?: ParseOptions) {
+    super(source, options);
+    const lexer = this._lexer;
+    this._lexer = new Proxy(lexer, {
+      get: (target, prop, receiver) => {
+        if (prop === 'advance') {
+          return () => {
+            const token = target.advance();
+            if (token.kind !== TokenKind.EOF) {
+              this.__tokenCount++;
+            }
+            return token;
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+  }
+}
+
+export function calculateTokenCount(args: {
+  source: Source | string;
+  getReferencedFragmentSource: (fragmentName: string) => Source | string | undefined;
+}): number {
+  const parser = new ParserWithLexer(args.source);
+  const document = parser.parseDocument();
+  let { tokenCount } = parser;
+
+  visit(document, {
+    FragmentSpread(node) {
+      const fragmentSource = args.getReferencedFragmentSource(node.name.value);
+      if (fragmentSource) {
+        tokenCount += calculateTokenCount({
+          source: fragmentSource,
+          getReferencedFragmentSource: args.getReferencedFragmentSource,
+        });
+      }
+    },
+  });
+
+  return tokenCount;
+}

--- a/packages/core/src/validate/token-count.ts
+++ b/packages/core/src/validate/token-count.ts
@@ -1,4 +1,4 @@
-import { TokenKind, visit } from 'graphql';
+import { DocumentNode, GraphQLError, TokenKind, visit } from 'graphql';
 import type { ParseOptions, Source } from 'graphql';
 import { Parser } from 'graphql/language/parser';
 
@@ -50,4 +50,21 @@ export function calculateTokenCount(args: {
   });
 
   return tokenCount;
+}
+
+export function validateTokenCount(args: {
+  source: Source;
+  document: DocumentNode;
+  getReferencedFragmentSource: (fragmentName: string) => Source | string | undefined;
+  maxTokenCount: number;
+}): GraphQLError | void {
+  const tokenCount = calculateTokenCount(args);
+  if (tokenCount > args.maxTokenCount) {
+    return new GraphQLError(
+      `Query exceeds maximum token count of ${args.maxTokenCount} (actual: ${tokenCount})`,
+      args.document,
+      args.source,
+      args.document.loc && args.document.loc.start ? [args.document.loc.start] : undefined
+    );
+  }
 }

--- a/website/src/pages/docs/essentials/audit.mdx
+++ b/website/src/pages/docs/essentials/audit.mdx
@@ -25,6 +25,9 @@ graphql-inspector audit './documents/*.graphql'
 ### Flags
 
 - `-d, --detail` - Print statistics for each single GraphQL operation (default: `false`)
+- `--complexityScalarCost` - The cost of a scalar field for calculating the complexity score (default: `1`)
+- `--complexityObjectCost` - The cost of an object field for calculating the complexity score (default: `2`)
+- `--complexityDepthCostFactor` - The cost factor of a field per depth level for calculating the complexity score (default: `1.5`)
 
 ### Output
 

--- a/website/src/pages/docs/essentials/audit.mdx
+++ b/website/src/pages/docs/essentials/audit.mdx
@@ -1,0 +1,36 @@
+# Audit Documents
+
+Audit your documents for useful metrics such as query depth, directive count and alias count. This is useful if you want
+to introduce security rules on your GraphQL server (e.g. via
+[`graphql-armor`](https://github.com/Escape-Technologies/graphql-armor)) and need to figure out the values for doing so.
+
+## Usage
+
+Run the following command:
+
+```sh
+graphql-inspector audit DOCUMENTS
+```
+
+### Example
+
+```sh
+graphql-inspector audit './documents/*.graphql'
+```
+
+### Arguments
+
+- [`DOCUMENTS`](../api/documents) - a glob pattern that points to GraphQL Documents / Operations
+
+### Flags
+
+- `-d, --detail` - Print statistics for each single GraphQL operation (default: `false`)
+
+### Output
+
+A list of metrics including the maximum depth limit, maximum alias count and maximum directive count.
+
+This process does not fail, as it is mainly for showing useful information. In case you want to enforce a certain query
+deth, directive count or alias count limit check the
+[`--maxDepth`, `--maxAliasCount` and `--maxDirectiveCount` flags in the Validate Documents](./validate.mdx)
+documentation.

--- a/website/src/pages/docs/essentials/meta.json
+++ b/website/src/pages/docs/essentials/meta.json
@@ -2,6 +2,7 @@
   "diff": "Schema Validation",
   "notifications": "Schema Change Notifications",
   "validate": "Validate Documents",
+  "audit": "Audit Documents",
   "coverage": "Schema Coverage",
   "similar": "Find Similar Types",
   "serve": "Serve With Faked Data",

--- a/website/src/pages/docs/essentials/validate.mdx
+++ b/website/src/pages/docs/essentials/validate.mdx
@@ -34,6 +34,10 @@ graphql-inspector validate './documents/*.graphql' http://localhost:3000/graphql
 - `--federation` - Support Apollo Federation directives (default: `false`)
 - `--aws` - Support AWS Appsync directives and scalar types (default: `false`)
 - `--maxDepth <n>` - Fail when operation depth exceeds maximum depth (default: `false`)
+- `--maxAliasCount <n>` - Fail when alias count (including the referenced fragments) exceeds maximum alias count
+  (default: `false`)
+- `--maxDirectiveCount <n>` - Fail when directive count in a operation (including the referenced fragments) exceeds
+  maximum directive count (default: `false`)
 - `--filter <s>` - show warnings and errors only for a file (or a list of files)
 - `--silent` - silent mode
 - `--output <s>` - writes errors to a file

--- a/website/src/pages/docs/essentials/validate.mdx
+++ b/website/src/pages/docs/essentials/validate.mdx
@@ -38,6 +38,8 @@ graphql-inspector validate './documents/*.graphql' http://localhost:3000/graphql
   (default: `false`)
 - `--maxDirectiveCount <n>` - Fail when directive count in a operation (including the referenced fragments) exceeds
   maximum directive count (default: `false`)
+- `--maxTokenCount <n>` - Fail when token count (including the referenced fragments) exceeds maximum token count
+  (default: `false`)
 - `--filter <s>` - show warnings and errors only for a file (or a list of files)
 - `--silent` - silent mode
 - `--output <s>` - writes errors to a file

--- a/yarn.lock
+++ b/yarn.lock
@@ -948,6 +948,11 @@
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.0.tgz#fe364f025ba74f6de6c837a84ef44bdb1d61e68f"
   integrity sha512-mgmE7XBYY/21erpzhexk4Cj1cyTQ9LzvnTxtzM17BJ7ERMNE6W72mQRo0I1Ud8eFJ+RVVIcBNhLFZ3GX4XFz5w==
 
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
 "@corex/deepmerge@^4.0.29":
   version "4.0.29"
   resolved "https://registry.yarnpkg.com/@corex/deepmerge/-/deepmerge-4.0.29.tgz#af9debf07d7f6b0d2a9d04a266abf2c1418ed2f6"
@@ -4329,6 +4334,15 @@ cli-cursor@^3.1.0:
   integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
   dependencies:
     restore-cursor "^3.1.0"
+
+cli-table3@0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.2.tgz#aaf5df9d8b5bf12634dc8b3040806a0c07120d2a"
+  integrity sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    "@colors/colors" "1.5.0"
 
 cli-truncate@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This adds the new `graphql-inspector validate` flags `--maxAliasCount` and `--maxDirectiveCount`.

it also introduces a new `graphql-inspector audit DOCUMENTS` command for detecting the optimal `--queryDepth`, `--maxAliasCount` and `--maxDirectiveCount` values for `graphql-inspector validate` when introducing something like [graphql-armor](https://github.com/Escape-Technologies/graphql-armor) on the server.