### PR TITLE
Marking breaking types as dangerous with the deprecated fields rule

### DIFF
--- a/.changeset/eighty-starfishes-refuse.md
+++ b/.changeset/eighty-starfishes-refuse.md
@@ -1,0 +1,5 @@
+---
+'@graphql-inspector/core': minor
+---
+
+suppressRemovalOfDeprecatedField rule will now mark removed types as dangerous

--- a/integration_tests/2239/newSchema.graphql
+++ b/integration_tests/2239/newSchema.graphql
@@ -1,0 +1,3 @@
+type Query {
+  newQuery: Int!
+}

--- a/integration_tests/2239/oldSchema.graphql
+++ b/integration_tests/2239/oldSchema.graphql
@@ -1,0 +1,8 @@
+type Query {
+  oldQuery: OldType @deprecated(reason: "use newQuery")
+  newQuery: Int!
+}
+
+type OldType {
+  field: String!
+}

--- a/packages/core/__tests__/diff/rules/suppress-removal-of-deprecated-fields.ts
+++ b/packages/core/__tests__/diff/rules/suppress-removal-of-deprecated-fields.ts
@@ -1,0 +1,113 @@
+import { buildSchema } from 'graphql';
+import { suppressRemovalOfDeprecatedField } from '../../../src/diff/rules';
+import { CriticalityLevel, diff } from '../../../src/index';
+import { findFirstChangeByPath } from '../../../utils/testing';
+
+describe('suppressRemovalOfDeprecatedFields rule', () => {
+  test('removed field on object', async () => {
+    const a = buildSchema(/* GraphQL */ `
+      type Foo {
+        a: String! @deprecated(reason: "use b")
+        b: String!
+      }
+    `);
+    const b = buildSchema(/* GraphQL */ `
+      type Foo {
+        b: String!
+      }
+    `);
+
+    const changes = await diff(a, b, [suppressRemovalOfDeprecatedField]);
+
+    const removed = findFirstChangeByPath(changes, 'Foo.a');
+
+    expect(removed.criticality.level).toBe(CriticalityLevel.Dangerous);
+  });
+
+  test('removed field on interface', async () => {
+    const a = buildSchema(/* GraphQL */ `
+      interface Foo {
+        a: String! @deprecated(reason: "use b")
+        b: String!
+      }
+    `);
+    const b = buildSchema(/* GraphQL */ `
+      interface Foo {
+        b: String!
+      }
+    `);
+
+    const changes = await diff(a, b, [suppressRemovalOfDeprecatedField]);
+
+    const removed = findFirstChangeByPath(changes, 'Foo.a');
+
+    expect(removed.criticality.level).toBe(CriticalityLevel.Dangerous);
+  });
+
+  test('removed enum', async () => {
+    const a = buildSchema(/* GraphQL */ `
+      enum Foo {
+        a @deprecated(reason: "use b")
+        b
+      }
+    `);
+    const b = buildSchema(/* GraphQL */ `
+      enum Foo {
+        b
+      }
+    `);
+
+    const changes = await diff(a, b, [suppressRemovalOfDeprecatedField]);
+
+    const removed = findFirstChangeByPath(changes, 'Foo.a');
+
+    expect(removed.criticality.level).toBe(CriticalityLevel.Dangerous);
+  });
+
+  test('removed input field', async () => {
+    const a = buildSchema(/* GraphQL */ `
+      input Foo {
+        a: String! @deprecated(reason: "use b")
+        b: String!
+      }
+    `);
+    const b = buildSchema(/* GraphQL */ `
+      input Foo {
+        b: String!
+      }
+    `);
+
+    const changes = await diff(a, b, [suppressRemovalOfDeprecatedField]);
+
+    const removed = findFirstChangeByPath(changes, 'Foo.a');
+
+    expect(removed.criticality.level).toBe(CriticalityLevel.Dangerous);
+  });
+
+  test('removed field with custom types', async () => {
+    const a = buildSchema(/* GraphQL */ `
+      type Foo {
+        a: CustomType! @deprecated(reason: "use b")
+        b: String!
+      }
+
+      type CustomType {
+        c: String!
+        d: String!
+      }
+    `);
+    const b = buildSchema(/* GraphQL */ `
+      type Foo {
+        b: String!
+      }
+    `);
+
+    const changes = await diff(a, b, [suppressRemovalOfDeprecatedField]);
+
+    const removedField = findFirstChangeByPath(changes, 'Foo.a');
+    const removedType = findFirstChangeByPath(changes, 'CustomType');
+
+    expect(removedField.criticality.level).toBe(CriticalityLevel.Dangerous);
+    expect(removedType.criticality.level).toBe(CriticalityLevel.Dangerous);
+  });
+});

--- a/packages/core/src/diff/rules/suppress-removal-of-deprecated-field.ts
+++ b/packages/core/src/diff/rules/suppress-removal-of-deprecated-field.ts
@@ -4,7 +4,7 @@ import { parsePath } from '../../utils/path';
 import { ChangeType, CriticalityLevel } from './../changes/change';
 import { Rule } from './types';
 
-export const suppressRemovalOfDeprecatedField: Rule = ({ changes, oldSchema }) => {
+export const suppressRemovalOfDeprecatedField: Rule = ({ changes, oldSchema, newSchema }) => {
   return changes.map(change => {
     if (
       change.type === ChangeType.FieldRemoved &&
@@ -81,7 +81,7 @@ export const suppressRemovalOfDeprecatedField: Rule = ({ changes, oldSchema }) =
       change.path
     ) {
       const [typeName] = parsePath(change.path);
-      const type = oldSchema.getType(typeName);
+      const type = newSchema.getType(typeName);
 
       if (!type) {
         return {

--- a/packages/core/src/diff/rules/suppress-removal-of-deprecated-field.ts
+++ b/packages/core/src/diff/rules/suppress-removal-of-deprecated-field.ts
@@ -75,6 +75,25 @@ export const suppressRemovalOfDeprecatedField: Rule = ({ changes, oldSchema }) =
       }
     }
 
+    if (
+      change.type === ChangeType.TypeRemoved &&
+      change.criticality.level === CriticalityLevel.Breaking &&
+      change.path
+    ) {
+      const [typeName] = parsePath(change.path);
+      const type = oldSchema.getType(typeName);
+
+      if (!type) {
+        return {
+          ...change,
+          criticality: {
+            ...change.criticality,
+            level: CriticalityLevel.Dangerous,
+          },
+        };
+      }
+    }
+
     return change;
   });
 };


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Adds an extra rule check to the `suppressRemovalOfDeprecatedField` rule that marks removed types as dangerous, not breaking

Fixes #2239

## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)

## How Has This Been Tested?

As described in the issue, and included in the branch, running `diff oldSchema.graphql newSchema.graphql --rule suppressRemovalOfDeprecatedField` reproduces the issue. I can't seem to figure out how to run the built version locally to test it out, maybe I could get some help with that?

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
