### PR TITLE
Fix Cli package installation warnings

### DIFF
--- a/.changeset/@graphql-inspector_cli-2254-dependencies.md
+++ b/.changeset/@graphql-inspector_cli-2254-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-inspector/cli": patch
+---
+dependencies updates:
+  - Added dependency [`@graphql-inspector/config@3.4.0` ↗︎](https://www.npmjs.com/package/@graphql-inspector/config/v/3.4.0) (to `dependencies`)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,6 +50,7 @@
     "@graphql-inspector/audit-command": "3.4.1",
     "@graphql-inspector/code-loader": "3.4.0",
     "@graphql-inspector/commands": "3.4.0",
+    "@graphql-inspector/config": "3.4.0",
     "@graphql-inspector/coverage-command": "3.4.1",
     "@graphql-inspector/diff-command": "3.4.1",
     "@graphql-inspector/docs-command": "3.4.0",


### PR DESCRIPTION
Close #1984 

**How to reproduce:**
`yarn global add @graphql-inspector/cli graphql`
**Result:**
```
yarn global v1.22.19
warning package.json: No license field
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning "@graphql-inspector/cli > @graphql-inspector/commands@3.4.0" has unmet peer dependency "@graphql-inspector/config@3.4.0".
warning "@graphql-inspector/cli > @graphql-inspector/loaders@3.4.0" has unmet peer dependency "@graphql-inspector/config@3.4.0".
warning "@graphql-inspector/cli > @graphql-inspector/loaders@3.4.0" has unmet peer dependency "@graphql-tools/utils@^6.0.0 || ^7.0.0 || ^8.0.0".
warning "@graphql-inspector/cli > @graphql-inspector/code-loader > @graphql-tools/code-file-loader > @graphql-tools/graphql-tag-pluck > @babel/plugin-syntax-import-assertions@7.20.0" has unmet peer dependency "@babel/core@^7.0.0-0".
[4/4] 🔨  Building fresh packages...
success Installed "@graphql-inspector/cli@3.4.1" with binaries:
      - graphql-inspector
warning "graphql@16.6.0" has no binaries
✨  Done in 7.88s.
```