### PR TITLE
Github: Adding option to send rules to the diff helper

### DIFF
--- a/.changeset/clever-bikes-check.md
+++ b/.changeset/clever-bikes-check.md
@@ -1,0 +1,5 @@
+---
+'@graphql-inspector/github': patch
+---
+
+Allowing rules to be passed through to `diff`

--- a/packages/github/__tests__/diff.ts
+++ b/packages/github/__tests__/diff.ts
@@ -1,4 +1,4 @@
-import { CriticalityLevel } from '@graphql-inspector/core';
+import { CriticalityLevel, DiffRule } from '@graphql-inspector/core';
 import { buildSchema, Source } from 'graphql';
 import nock from 'nock';
 import { diff, DiffInterceptorPayload, DiffInterceptorResponse } from '../src/helpers/diff';
@@ -208,4 +208,41 @@ test('use interceptor to modify check conclusion', async () => {
   expect(action.conclusion).toBe(CheckConclusion.Neutral);
 
   scope.done();
+});
+
+test('should apply the rule suppressRemovalOfDeprecatedField to the diff', async () => {
+  const { schemas, sources } = build(
+    /* GraphQL */ `
+      type Post {
+        id: ID!
+        title: String @deprecated(reason: "No more used")
+        createdAt: String!
+      }
+
+      type Query {
+        post: Post!
+      }
+    `,
+    /* GraphQL */ `
+      type Post {
+        id: ID!
+        createdAt: String!
+      }
+
+      type Query {
+        post: Post!
+      }
+    `,
+  );
+
+  const action = await diff({
+    path: 'schema.graphql',
+    rules: [DiffRule.suppressRemovalOfDeprecatedField],
+    schemas,
+    sources,
+  });
+
+  expect(action.annotations).toHaveLength(1);
+  expect(action.changes).toHaveLength(1);
+  expect(action.conclusion).toBe(CheckConclusion.Success);
 });

--- a/packages/github/src/helpers/diff.ts
+++ b/packages/github/src/helpers/diff.ts
@@ -33,6 +33,7 @@ export async function diff({
   pullRequests,
   ref,
   rules,
+  config,
 }: {
   path: string;
   schemas: {
@@ -47,8 +48,9 @@ export async function diff({
   pullRequests?: PullRequest[];
   ref?: string;
   rules?: Rule[];
+  config?: Parameters<typeof diffSchemas>[3];
 }): Promise<ActionResult> {
-  let changes = await diffSchemas(schemas.old, schemas.new, rules);
+  let changes = await diffSchemas(schemas.old, schemas.new, rules, config);
   let forcedConclusion: CheckConclusion | null = null;
 
   if (!changes || !changes.length) {

--- a/packages/github/src/helpers/diff.ts
+++ b/packages/github/src/helpers/diff.ts
@@ -1,4 +1,4 @@
-import { Change, CriticalityLevel, diff as diffSchemas } from '@graphql-inspector/core';
+import { Change, CriticalityLevel, diff as diffSchemas, Rule } from '@graphql-inspector/core';
 import axios from 'axios';
 import { GraphQLSchema, Source } from 'graphql';
 import { getLocationByPath } from './location';
@@ -32,6 +32,7 @@ export async function diff({
   interceptor,
   pullRequests,
   ref,
+  rules,
 }: {
   path: string;
   schemas: {
@@ -45,8 +46,9 @@ export async function diff({
   interceptor?: DiffInterceptor;
   pullRequests?: PullRequest[];
   ref?: string;
+  rules?: Rule[];
 }): Promise<ActionResult> {
-  let changes = await diffSchemas(schemas.old, schemas.new);
+  let changes = await diffSchemas(schemas.old, schemas.new, rules);
   let forcedConclusion: CheckConclusion | null = null;
 
   if (!changes || !changes.length) {


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Adds an optional pass-through for rules to the `diff` command in `github/helpers`

Part of #2250

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Unit tests cover this feature

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

As the action I want to update relies on this addition being there, I assume I need to have this package published first before it can be used in the action. Please let me know if there's a way to do this in fewer PRs.
