### PR TITLE
feat: export meta data

### DIFF
--- a/packages/core/src/diff/changes/argument.ts
+++ b/packages/core/src/diff/changes/argument.ts
@@ -1,22 +1,50 @@
 import { GraphQLArgument, GraphQLField, GraphQLInterfaceType, GraphQLObjectType } from 'graphql';
 import { safeChangeForInputValue } from '../../utils/graphql';
 import { safeString } from '../../utils/string';
-import { Change, ChangeType, CriticalityLevel } from './change';
+import {
+  Change,
+  ChangeType,
+  CriticalityLevel,
+  FieldArgumentDefaultChanged,
+  FieldArgumentDescriptionChanged,
+  FieldArgumentTypeChanged,
+} from './change';
+
+function buildFieldArgumentDescriptionChangedMessage(
+  args: FieldArgumentDescriptionChanged,
+): string {
+  return `Description for argument '${args.meta.argumentName}' on field '${args.meta.typeName}.${args.meta.fieldName}' changed from '${args.meta.oldDescription}' to '${args.meta.newDescription}'`;
+}
 
 export function fieldArgumentDescriptionChanged(
   type: GraphQLObjectType | GraphQLInterfaceType,
   field: GraphQLField<any, any, any>,
   oldArg: GraphQLArgument,
   newArg: GraphQLArgument,
-): Change {
+): Change<ChangeType.FieldArgumentDescriptionChanged> {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.FieldArgumentDescriptionChanged,
-    message: `Description for argument '${newArg.name}' on field '${type.name}.${field.name}' changed from '${oldArg.description}' to '${newArg.description}'`,
+    get message() {
+      return buildFieldArgumentDescriptionChangedMessage(this);
+    },
     path: [type.name, field.name, oldArg.name].join('.'),
+    meta: {
+      typeName: type.name,
+      fieldName: field.name,
+      argumentName: oldArg.name,
+      oldDescription: oldArg.description ?? null,
+      newDescription: newArg.description ?? null,
+    },
   };
+}
+
+function buildFieldArgumentDefaultChangedMessage(args: FieldArgumentDefaultChanged): string {
+  return args.meta.oldDefaultValue === undefined
+    ? `Default value '${args.meta.newDefaultValue}' was added to argument '${args.meta.argumentName}' on field '${args.meta.typeName}.${args.meta.fieldName}'`
+    : `Default value for argument '${args.meta.argumentName}' on field '${args.meta.typeName}.${args.meta.fieldName}' changed from '${args.meta.oldDefaultValue}' to '${args.meta.newDefaultValue}'`;
 }
 
 export function fieldArgumentDefaultChanged(
@@ -24,7 +52,7 @@ export function fieldArgumentDefaultChanged(
   field: GraphQLField<any, any, any>,
   oldArg: GraphQLArgument,
   newArg: GraphQLArgument,
-): Change {
+): Change<ChangeType.FieldArgumentDefaultChanged> {
   return {
     criticality: {
       level: CriticalityLevel.Dangerous,
@@ -32,18 +60,24 @@ export function fieldArgumentDefaultChanged(
         'Changing the default value for an argument may change the runtime behaviour of a field if it was never provided.',
     },
     type: ChangeType.FieldArgumentDefaultChanged,
-    message:
-      typeof oldArg.defaultValue === 'undefined'
-        ? `Default value '${safeString(newArg.defaultValue)}' was added to argument '${
-            newArg.name
-          }' on field '${type.name}.${field.name}'`
-        : `Default value for argument '${newArg.name}' on field '${type.name}.${
-            field.name
-          }' changed from '${safeString(oldArg.defaultValue)}' to '${safeString(
-            newArg.defaultValue,
-          )}'`,
+    get message() {
+      return buildFieldArgumentDefaultChangedMessage(this);
+    },
     path: [type.name, field.name, oldArg.name].join('.'),
+    meta: {
+      typeName: type.name,
+      fieldName: field.name,
+      argumentName: newArg.name,
+      oldDefaultValue:
+        oldArg.defaultValue == undefined ? undefined : safeString(oldArg.defaultValue),
+      newDefaultValue:
+        newArg.defaultValue == undefined ? undefined : safeString(newArg.defaultValue),
+    },
   };
+}
+
+function buildFieldArgumentTypeChangedMessage(args: FieldArgumentTypeChanged): string {
+  return `Type for argument '${args.meta.argumentName}' on field '${args.meta.typeName}.${args.meta.fieldName}' changed from '${args.meta.oldArgumentType}' to '${args.meta.newArgumentType}'`;
 }
 
 export function fieldArgumentTypeChanged(
@@ -51,7 +85,7 @@ export function fieldArgumentTypeChanged(
   field: GraphQLField<any, any, any>,
   oldArg: GraphQLArgument,
   newArg: GraphQLArgument,
-): Change {
+): Change<ChangeType.FieldArgumentTypeChanged> {
   return {
     criticality: safeChangeForInputValue(oldArg.type, newArg.type)
       ? {
@@ -63,7 +97,16 @@ export function fieldArgumentTypeChanged(
           reason: `Changing the type of a field's argument can cause existing queries that use this argument to error.`,
         },
     type: ChangeType.FieldArgumentTypeChanged,
-    message: `Type for argument '${newArg.name}' on field '${type.name}.${field.name}' changed from '${oldArg.type}' to '${newArg.type}'`,
+    get message() {
+      return buildFieldArgumentTypeChangedMessage(this);
+    },
     path: [type.name, field.name, oldArg.name].join('.'),
+    meta: {
+      typeName: type.name,
+      fieldName: field.name,
+      argumentName: newArg.name,
+      oldArgumentType: oldArg.type.toString(),
+      newArgumentType: newArg.type.toString(),
+    },
   };
 }

--- a/packages/core/src/diff/changes/change.ts
+++ b/packages/core/src/diff/changes/change.ts
@@ -75,9 +75,564 @@ export interface Criticality {
   reason?: string;
 }
 
-export interface Change {
+export interface Change<TChange extends keyof Changes = any> {
   message: string;
   path?: string;
-  type: ChangeType;
+  type: TChange;
+  meta: Changes[TChange]['meta'];
   criticality: Criticality;
 }
+
+// Directive
+
+export type FieldArgumentDescriptionChanged = {
+  type: ChangeType.FieldArgumentDescriptionChanged;
+  meta: {
+    typeName: string;
+    fieldName: string;
+    argumentName: string;
+    oldDescription: string | null;
+    newDescription: string | null;
+  };
+};
+
+export type FieldArgumentDefaultChanged = {
+  type: ChangeType.FieldArgumentDefaultChanged;
+  meta: {
+    typeName: string;
+    fieldName: string;
+    argumentName: string;
+    oldDefaultValue: string | undefined;
+    newDefaultValue: string | undefined;
+  };
+};
+
+export type FieldArgumentTypeChanged = {
+  type: ChangeType.FieldArgumentTypeChanged;
+  meta: {
+    typeName: string;
+    fieldName: string;
+    argumentName: string;
+    oldArgumentType: string;
+    newArgumentType: string;
+  };
+};
+
+export type DirectiveRemoved = {
+  type: ChangeType.DirectiveRemoved;
+  meta: {
+    removedDirectiveName: string;
+  };
+};
+
+export type DirectiveAdded = {
+  type: ChangeType.DirectiveAdded;
+  meta: {
+    addedDirectiveName: string;
+  };
+};
+
+export type DirectiveDescriptionChanged = {
+  type: ChangeType.DirectiveDescriptionChanged;
+  meta: {
+    directiveName: string;
+    oldDirectiveDescription: string | null;
+    newDirectiveDescription: string | null;
+  };
+};
+
+export type DirectiveLocationAdded = {
+  type: ChangeType.DirectiveLocationAdded;
+  meta: {
+    directiveName: string;
+    addedDirectiveLocation: string;
+  };
+};
+
+export type DirectiveLocationRemoved = {
+  type: ChangeType.DirectiveLocationAdded;
+  meta: {
+    directiveName: string;
+    removedDirectiveLocation: string;
+  };
+};
+
+export type DirectiveArgumentAdded = {
+  type: ChangeType.DirectiveArgumentAdded;
+  meta: {
+    directiveName: string;
+    addedDirectiveArgumentName: string;
+    addedDirectiveArgumentType: string;
+  };
+};
+
+export type DirectiveArgumentRemoved = {
+  type: ChangeType.DirectiveArgumentRemoved;
+  meta: {
+    directiveName: string;
+    removedDirectiveArgumentName: string;
+    removedDirectiveArgumentType: string;
+  };
+};
+
+export type DirectiveArgumentDescriptionChanged = {
+  type: ChangeType.DirectiveArgumentDescriptionChanged;
+  meta: {
+    directiveName: string;
+    directiveArgumentName: string;
+    oldDirectiveArgumentDescription: string | null;
+    newDirectiveArgumentDescription: string | null;
+  };
+};
+
+export type DirectiveArgumentDefaultValueChanged = {
+  type: ChangeType.DirectiveArgumentDefaultValueChanged;
+  meta: {
+    directiveName: string;
+    directiveArgumentName: string;
+    oldDirectiveArgumentDefaultValue: string;
+    newDirectiveArgumentDefaultValue: string;
+  };
+};
+
+export type DirectiveArgumentTypeChanged = {
+  type: ChangeType.DirectiveArgumentTypeChanged;
+  meta: {
+    directiveName: string;
+    directiveArgumentName: string;
+    oldDirectiveArgumentType: string;
+    newDirectiveArgumentType: string;
+  };
+};
+
+// Enum
+
+export type EnumValueRemoved = {
+  type: ChangeType.EnumValueRemoved;
+  meta: {
+    enumName: string;
+    removedEnumValueName: string;
+    isEnumValueDeprecated: boolean;
+  };
+};
+
+export type EnumValueAdded = {
+  type: ChangeType.EnumValueAdded;
+  meta: {
+    enumName: string;
+    addedEnumValueName: string;
+  };
+};
+
+export type EnumValueDescriptionChanged = {
+  type: ChangeType.EnumValueDescriptionChanged;
+  meta: {
+    enumName: string;
+    enumValueName: string;
+    oldEnumValueDescription: string | null;
+    newEnumValueDescription: string | null;
+  };
+};
+
+export type EnumValueDeprecationReasonChanged = {
+  type: ChangeType.EnumValueDeprecationReasonChanged;
+  meta: {
+    enumName: string;
+    enumValueName: string;
+    oldEnumValueDeprecationReason: string;
+    newEnumValueDeprecationReason: string;
+  };
+};
+
+export type EnumValueDeprecationReasonAdded = {
+  type: ChangeType.EnumValueDeprecationReasonAdded;
+  meta: {
+    enumName: string;
+    enumValueName: string;
+    addedValueDeprecationReason: string;
+  };
+};
+
+export type EnumValueDeprecationReasonRemoved = {
+  type: ChangeType.EnumValueDeprecationReasonRemoved;
+  meta: {
+    enumName: string;
+    enumValueName: string;
+    removedEnumValueDeprecationReason: string;
+  };
+};
+
+// Field
+
+export type FieldRemoved = {
+  type: ChangeType.FieldRemoved;
+  meta: {
+    typeName: string;
+    removedFieldName: string;
+    isRemovedFieldDeprecated: boolean;
+    typeType: string;
+  };
+};
+
+export type FieldAdded = {
+  type: ChangeType.FieldAdded;
+  meta: {
+    typeName: string;
+    addedFieldName: string;
+    typeType: string;
+  };
+};
+
+export type FieldDescriptionChanged = {
+  type: ChangeType.FieldDescriptionChanged;
+  meta: {
+    typeName: string;
+    fieldName: string;
+    oldDescription: string;
+    newDescription: string;
+  };
+};
+
+export type FieldDescriptionAdded = {
+  type: ChangeType.FieldDescriptionAdded;
+  meta: {
+    typeName: string;
+    fieldName: string;
+    addedDescription: string;
+  };
+};
+
+export type FieldDescriptionRemoved = {
+  type: ChangeType.FieldDescriptionRemoved;
+  meta: {
+    typeName: string;
+    fieldName: string;
+  };
+};
+
+export type FieldDeprecationAdded = {
+  type: ChangeType.FieldDeprecationAdded;
+  meta: {
+    typeName: string;
+    fieldName: string;
+  };
+};
+
+export type FieldDeprecationRemoved = {
+  type: ChangeType.FieldDeprecationRemoved;
+  meta: {
+    typeName: string;
+    fieldName: string;
+  };
+};
+
+export type FieldDeprecationReasonChanged = {
+  type: ChangeType.FieldDeprecationReasonChanged;
+  meta: {
+    typeName: string;
+    fieldName: string;
+    oldDeprecationReason: string;
+    newDeprecationReason: string;
+  };
+};
+
+export type FieldDeprecationReasonAdded = {
+  type: ChangeType.FieldDeprecationReasonAdded;
+  meta: {
+    typeName: string;
+    fieldName: string;
+    addedDeprecationReason: string;
+  };
+};
+
+export type FieldDeprecationReasonRemoved = {
+  type: ChangeType.FieldDeprecationReasonRemoved;
+  meta: {
+    typeName: string;
+    fieldName: string;
+  };
+};
+
+export type FieldTypeChanged = {
+  type: ChangeType.FieldTypeChanged;
+  meta: {
+    typeName: string;
+    fieldName: string;
+    oldFieldType: string;
+    newFieldType: string;
+  };
+};
+
+export type FieldArgumentAdded = {
+  type: ChangeType.FieldArgumentAdded;
+  meta: {
+    typeName: string;
+    fieldName: string;
+    addedArgumentName: string;
+    addedArgumentType: string;
+    hasDefaultValue: boolean;
+  };
+};
+
+export type FieldArgumentRemoved = {
+  type: ChangeType.FieldArgumentRemoved;
+  meta: {
+    typeName: string;
+    fieldName: string;
+    removedFieldArgumentName: string;
+    removedFieldType: string;
+  };
+};
+
+// Input
+
+export type InputFieldRemoved = {
+  type: ChangeType.InputFieldRemoved;
+  meta: {
+    inputName: string;
+    removedFieldName: string;
+    isInputFieldDeprecated: boolean;
+  };
+};
+
+export type InputFieldAdded = {
+  type: ChangeType.InputFieldAdded;
+  meta: {
+    inputName: string;
+    addedInputFieldName: string;
+  };
+};
+
+export type InputFieldDescriptionAdded = {
+  type: ChangeType.InputFieldDescriptionAdded;
+  meta: {
+    inputName: string;
+    inputFieldName: string;
+    addedInputFieldDescription: string;
+  };
+};
+
+export type InputFieldDescriptionRemoved = {
+  type: ChangeType.InputFieldDescriptionRemoved;
+  meta: {
+    inputName: string;
+    inputFieldName: string;
+  };
+};
+
+export type InputFieldDescriptionChanged = {
+  type: ChangeType.InputFieldDescriptionChanged;
+  meta: {
+    inputName: string;
+    inputFieldName: string;
+    oldInputFieldDescription: string;
+    newInputFieldDescription: string;
+  };
+};
+
+export type InputFieldDefaultValueChanged = {
+  type: ChangeType.InputFieldDefaultValueChanged;
+  meta: {
+    inputName: string;
+    inputFieldName: string;
+    oldDefaultValue: string /* null | */ | undefined;
+    newDefaultValue: string /* null | */ | undefined;
+  };
+};
+
+export type InputFieldTypeChanged = {
+  type: ChangeType.InputFieldTypeChanged;
+  meta: {
+    inputName: string;
+    inputFieldName: string;
+    oldInputFieldType: string;
+    newInputFieldType: string;
+  };
+};
+
+// Type
+
+export type ObjectTypeInterfaceAdded = {
+  type: ChangeType.ObjectTypeInterfaceAdded;
+  meta: {
+    objectTypeName: string;
+    addedInterfaceName: string;
+  };
+};
+
+export type ObjectTypeInterfaceRemoved = {
+  type: ChangeType.ObjectTypeInterfaceRemoved;
+  meta: {
+    objectTypeName: string;
+    removedInterfaceName: string;
+  };
+};
+
+// Schema
+
+export type SchemaQueryTypeChanged = {
+  type: ChangeType.SchemaQueryTypeChanged;
+  meta: {
+    oldQueryTypeName: string;
+    newQueryTypeName: string;
+  };
+};
+
+export type SchemaMutationTypeChanged = {
+  type: ChangeType.SchemaMutationTypeChanged;
+  meta: {
+    oldMutationTypeName: string;
+    newMutationTypeName: string;
+  };
+};
+
+export type SchemaSubscriptionTypeChanged = {
+  type: ChangeType.SchemaSubscriptionTypeChanged;
+  meta: {
+    oldSubscriptionTypeName: string;
+    newSubscriptionTypeName: string;
+  };
+};
+
+// Type
+
+export type TypeRemoved = {
+  type: ChangeType.TypeRemoved;
+  meta: {
+    removedTypeName: string;
+  };
+};
+
+export type TypeAdded = {
+  type: ChangeType.TypeAdded;
+  meta: {
+    addedTypeName: string;
+  };
+};
+
+export type TypeKindChanged = {
+  type: ChangeType.TypeKindChanged;
+  meta: {
+    typeName: string;
+    oldTypeKind: string;
+    newTypeKind: string;
+  };
+};
+
+export type TypeDescriptionChanged = {
+  type: ChangeType.TypeDescriptionChanged;
+  meta: {
+    typeName: string;
+    oldTypeDescription: string;
+    newTypeDescription: string;
+  };
+};
+
+export type TypeDescriptionAdded = {
+  type: ChangeType.TypeDescriptionAdded;
+  meta: {
+    typeName: string;
+    addedTypeDescription: string;
+  };
+};
+
+export type TypeDescriptionRemoved = {
+  type: ChangeType.TypeDescriptionRemoved;
+  meta: {
+    typeName: string;
+    removedTypeDescription: string;
+  };
+};
+
+// Union
+
+export type UnionMemberRemoved = {
+  type: ChangeType.UnionMemberRemoved;
+  meta: {
+    unionName: string;
+    removedUnionMemberTypeName: string;
+  };
+};
+
+export type UnionMemberAdded = {
+  type: ChangeType.UnionMemberAdded;
+  meta: {
+    unionName: string;
+    addedUnionMemberTypeName: string;
+  };
+};
+
+type Changes = {
+  [ChangeType.TypeAdded]: TypeAdded;
+  [ChangeType.TypeRemoved]: TypeRemoved;
+  [ChangeType.TypeKindChanged]: TypeKindChanged;
+  [ChangeType.TypeDescriptionChanged]: TypeDescriptionChanged;
+  [ChangeType.TypeDescriptionAdded]: TypeDescriptionAdded;
+  [ChangeType.TypeDescriptionRemoved]: TypeDescriptionRemoved;
+  [ChangeType.UnionMemberRemoved]: UnionMemberRemoved;
+  [ChangeType.UnionMemberAdded]: UnionMemberAdded;
+  [ChangeType.SchemaQueryTypeChanged]: SchemaQueryTypeChanged;
+  [ChangeType.SchemaMutationTypeChanged]: SchemaMutationTypeChanged;
+  [ChangeType.SchemaSubscriptionTypeChanged]: SchemaSubscriptionTypeChanged;
+  [ChangeType.ObjectTypeInterfaceAdded]: ObjectTypeInterfaceAdded;
+  [ChangeType.ObjectTypeInterfaceRemoved]: ObjectTypeInterfaceRemoved;
+  [ChangeType.InputFieldRemoved]: InputFieldRemoved;
+  [ChangeType.InputFieldAdded]: InputFieldAdded;
+  [ChangeType.InputFieldDescriptionAdded]: InputFieldDescriptionAdded;
+  [ChangeType.InputFieldDescriptionRemoved]: InputFieldDescriptionRemoved;
+  [ChangeType.InputFieldDescriptionChanged]: InputFieldDescriptionChanged;
+  [ChangeType.InputFieldDefaultValueChanged]: InputFieldDefaultValueChanged;
+  [ChangeType.InputFieldTypeChanged]: InputFieldTypeChanged;
+  [ChangeType.FieldRemoved]: FieldRemoved;
+  [ChangeType.FieldAdded]: FieldAdded;
+  [ChangeType.FieldDescriptionAdded]: FieldDescriptionAdded;
+  [ChangeType.FieldDescriptionRemoved]: FieldDescriptionRemoved;
+  [ChangeType.FieldDescriptionChanged]: FieldDescriptionChanged;
+  [ChangeType.FieldArgumentAdded]: FieldArgumentAdded;
+  [ChangeType.FieldArgumentRemoved]: FieldArgumentRemoved;
+  [ChangeType.InputFieldRemoved]: InputFieldRemoved;
+  [ChangeType.InputFieldAdded]: InputFieldAdded;
+  [ChangeType.InputFieldDescriptionAdded]: InputFieldDescriptionAdded;
+  [ChangeType.InputFieldDescriptionRemoved]: InputFieldDescriptionRemoved;
+  [ChangeType.InputFieldDescriptionChanged]: InputFieldDescriptionChanged;
+  [ChangeType.InputFieldDefaultValueChanged]: InputFieldDefaultValueChanged;
+  [ChangeType.InputFieldTypeChanged]: InputFieldTypeChanged;
+  [ChangeType.ObjectTypeInterfaceAdded]: ObjectTypeInterfaceAdded;
+  [ChangeType.ObjectTypeInterfaceRemoved]: ObjectTypeInterfaceRemoved;
+  [ChangeType.SchemaQueryTypeChanged]: SchemaQueryTypeChanged;
+  [ChangeType.SchemaMutationTypeChanged]: SchemaMutationTypeChanged;
+  [ChangeType.SchemaSubscriptionTypeChanged]: SchemaSubscriptionTypeChanged;
+  [ChangeType.TypeAdded]: TypeAdded;
+  [ChangeType.TypeRemoved]: TypeRemoved;
+  [ChangeType.TypeKindChanged]: TypeKindChanged;
+  [ChangeType.TypeDescriptionChanged]: TypeDescriptionChanged;
+  [ChangeType.TypeDescriptionRemoved]: TypeDescriptionRemoved;
+  [ChangeType.TypeDescriptionAdded]: TypeDescriptionAdded;
+  [ChangeType.UnionMemberAdded]: UnionMemberAdded;
+  [ChangeType.UnionMemberRemoved]: UnionMemberRemoved;
+  [ChangeType.DirectiveRemoved]: DirectiveRemoved;
+  [ChangeType.DirectiveAdded]: DirectiveAdded;
+  [ChangeType.DirectiveArgumentAdded]: DirectiveArgumentAdded;
+  [ChangeType.DirectiveArgumentRemoved]: DirectiveArgumentRemoved;
+  [ChangeType.DirectiveArgumentDescriptionChanged]: DirectiveArgumentDescriptionChanged;
+  [ChangeType.DirectiveArgumentDefaultValueChanged]: DirectiveArgumentDefaultValueChanged;
+  [ChangeType.DirectiveArgumentTypeChanged]: DirectiveArgumentTypeChanged;
+  [ChangeType.DirectiveDescriptionChanged]: DirectiveDescriptionChanged;
+  [ChangeType.FieldArgumentDescriptionChanged]: FieldArgumentDescriptionChanged;
+  [ChangeType.FieldArgumentDefaultChanged]: FieldArgumentDefaultChanged;
+  [ChangeType.FieldArgumentTypeChanged]: FieldArgumentTypeChanged;
+  [ChangeType.DirectiveLocationAdded]: DirectiveLocationAdded;
+  [ChangeType.DirectiveLocationRemoved]: DirectiveLocationRemoved;
+  [ChangeType.EnumValueRemoved]: EnumValueRemoved;
+  [ChangeType.EnumValueDescriptionChanged]: EnumValueDescriptionChanged;
+  [ChangeType.EnumValueDeprecationReasonChanged]: EnumValueDeprecationReasonChanged;
+  [ChangeType.EnumValueDeprecationReasonAdded]: EnumValueDeprecationReasonAdded;
+  [ChangeType.EnumValueDeprecationReasonRemoved]: EnumValueDeprecationReasonRemoved;
+  [ChangeType.EnumValueAdded]: EnumValueAdded;
+  [ChangeType.FieldDeprecationAdded]: FieldDeprecationAdded;
+  [ChangeType.FieldDeprecationRemoved]: FieldDeprecationRemoved;
+  [ChangeType.FieldDeprecationReasonChanged]: FieldDeprecationReasonChanged;
+  [ChangeType.FieldDeprecationReasonAdded]: FieldDeprecationReasonAdded;
+  [ChangeType.FieldDeprecationReasonRemoved]: FieldDeprecationReasonRemoved;
+  [ChangeType.FieldTypeChanged]: FieldTypeChanged;
+};

--- a/packages/core/src/diff/changes/change.ts
+++ b/packages/core/src/diff/changes/change.ts
@@ -115,6 +115,7 @@ export type FieldArgumentTypeChanged = {
     argumentName: string;
     oldArgumentType: string;
     newArgumentType: string;
+    isSafeArgumentTypeChange: boolean;
   };
 };
 
@@ -150,7 +151,7 @@ export type DirectiveLocationAdded = {
 };
 
 export type DirectiveLocationRemoved = {
-  type: ChangeType.DirectiveLocationAdded;
+  type: ChangeType.DirectiveLocationRemoved;
   meta: {
     directiveName: string;
     removedDirectiveLocation: string;
@@ -162,7 +163,7 @@ export type DirectiveArgumentAdded = {
   meta: {
     directiveName: string;
     addedDirectiveArgumentName: string;
-    addedDirectiveArgumentType: string;
+    addedDirectiveArgumentTypeIsNonNull: boolean;
   };
 };
 
@@ -171,7 +172,6 @@ export type DirectiveArgumentRemoved = {
   meta: {
     directiveName: string;
     removedDirectiveArgumentName: string;
-    removedDirectiveArgumentType: string;
   };
 };
 
@@ -190,8 +190,8 @@ export type DirectiveArgumentDefaultValueChanged = {
   meta: {
     directiveName: string;
     directiveArgumentName: string;
-    oldDirectiveArgumentDefaultValue: string;
-    newDirectiveArgumentDefaultValue: string;
+    oldDirectiveArgumentDefaultValue: string /* | null */ | undefined;
+    newDirectiveArgumentDefaultValue: string /* | null */ | undefined;
   };
 };
 
@@ -202,6 +202,8 @@ export type DirectiveArgumentTypeChanged = {
     directiveArgumentName: string;
     oldDirectiveArgumentType: string;
     newDirectiveArgumentType: string;
+    /** Note: this could also be computed from oldDirectiveArgumentType and newDirectiveArgumentType */
+    isSafeDirectiveArgumentTypeChange: boolean;
   };
 };
 
@@ -360,6 +362,7 @@ export type FieldTypeChanged = {
     fieldName: string;
     oldFieldType: string;
     newFieldType: string;
+    isSafeFieldTypeChange: boolean;
   };
 };
 
@@ -371,6 +374,7 @@ export type FieldArgumentAdded = {
     addedArgumentName: string;
     addedArgumentType: string;
     hasDefaultValue: boolean;
+    isAddedFieldArgumentBreaking: boolean;
   };
 };
 
@@ -400,6 +404,7 @@ export type InputFieldAdded = {
   meta: {
     inputName: string;
     addedInputFieldName: string;
+    isAddedInputFieldTypeNullable: boolean;
   };
 };
 
@@ -447,6 +452,7 @@ export type InputFieldTypeChanged = {
     inputFieldName: string;
     oldInputFieldType: string;
     newInputFieldType: string;
+    isInputFieldTypeChangeSafe: boolean;
   };
 };
 

--- a/packages/core/src/diff/changes/directive.ts
+++ b/packages/core/src/diff/changes/directive.ts
@@ -1,46 +1,86 @@
 import { DirectiveLocationEnum, GraphQLArgument, GraphQLDirective, isNonNullType } from 'graphql';
 import { safeChangeForInputValue } from '../../utils/graphql';
-import { Change, ChangeType, CriticalityLevel } from './change';
+import { safeString } from '../../utils/string';
+import {
+  Change,
+  ChangeType,
+  CriticalityLevel,
+  DirectiveAdded,
+  DirectiveDescriptionChanged,
+  DirectiveRemoved,
+} from './change';
 
-export function directiveRemoved(directive: GraphQLDirective): Change {
+function buildDirectiveRemovedMessage(directive: DirectiveRemoved): string {
+  return `Directive '${directive.meta.removedDirectiveName}' was removed`;
+}
+
+export function directiveRemoved(directive: GraphQLDirective): Change<ChangeType.DirectiveRemoved> {
   return {
     criticality: {
       level: CriticalityLevel.Breaking,
     },
     type: ChangeType.DirectiveRemoved,
-    message: `Directive '${directive.name}' was removed`,
+    get message() {
+      return buildDirectiveRemovedMessage(this);
+    },
     path: `@${directive.name}`,
+    meta: {
+      removedDirectiveName: directive.name,
+    },
   };
 }
-export function directiveAdded(directive: GraphQLDirective): Change {
+
+function buildDirectiveAddedMessage(directive: DirectiveAdded): string {
+  return `Directive '${directive.meta.addedDirectiveName}' was added`;
+}
+
+export function directiveAdded(directive: GraphQLDirective): Change<ChangeType.DirectiveAdded> {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.DirectiveAdded,
-    message: `Directive '${directive.name}' was added`,
+    get message() {
+      return buildDirectiveAddedMessage(this);
+    },
     path: `@${directive.name}`,
+    meta: {
+      addedDirectiveName: directive.name,
+    },
   };
+}
+
+function buildDirectiveDescriptionChangedMessage(directive: DirectiveDescriptionChanged): string {
+  return `Directive '${directive.meta.directiveName}' description changed from '${
+    directive.meta.oldDirectiveDescription ?? 'undefined'
+  }' to '${directive.meta.newDirectiveDescription ?? 'undefined'}'`;
 }
 
 export function directiveDescriptionChanged(
   oldDirective: GraphQLDirective,
   newDirective: GraphQLDirective,
-): Change {
+): Change<ChangeType.DirectiveDescriptionChanged> {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.DirectiveDescriptionChanged,
-    message: `Directive '${oldDirective.name}' description changed from '${oldDirective.description}' to '${newDirective.description}'`,
+    get message() {
+      return buildDirectiveDescriptionChangedMessage(this);
+    },
     path: `@${oldDirective.name}`,
+    meta: {
+      directiveName: oldDirective.name,
+      oldDirectiveDescription: oldDirective.description ?? null,
+      newDirectiveDescription: newDirective.description ?? null,
+    },
   };
 }
 
 export function directiveLocationAdded(
   directive: GraphQLDirective,
   location: DirectiveLocationEnum,
-): Change {
+): Change<ChangeType.DirectiveLocationAdded> {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
@@ -48,13 +88,17 @@ export function directiveLocationAdded(
     type: ChangeType.DirectiveLocationAdded,
     message: `Location '${location}' was added to directive '${directive.name}'`,
     path: `@${directive.name}`,
+    meta: {
+      directiveName: directive.name,
+      addedDirectiveLocation: location.toString(),
+    },
   };
 }
 
 export function directiveLocationRemoved(
   directive: GraphQLDirective,
   location: DirectiveLocationEnum,
-): Change {
+): Change<ChangeType.DirectiveLocationRemoved> {
   return {
     criticality: {
       level: CriticalityLevel.Breaking,
@@ -62,10 +106,17 @@ export function directiveLocationRemoved(
     type: ChangeType.DirectiveLocationRemoved,
     message: `Location '${location}' was removed from directive '${directive.name}'`,
     path: `@${directive.name}`,
+    meta: {
+      directiveName: directive.name,
+      removedDirectiveLocation: location.toString(),
+    },
   };
 }
 
-export function directiveArgumentAdded(directive: GraphQLDirective, arg: GraphQLArgument): Change {
+export function directiveArgumentAdded(
+  directive: GraphQLDirective,
+  arg: GraphQLArgument,
+): Change<ChangeType.DirectiveArgumentAdded> {
   return {
     criticality: {
       level: isNonNullType(arg.type) ? CriticalityLevel.Breaking : CriticalityLevel.NonBreaking,
@@ -73,13 +124,18 @@ export function directiveArgumentAdded(directive: GraphQLDirective, arg: GraphQL
     type: ChangeType.DirectiveArgumentAdded,
     message: `Argument '${arg.name}' was added to directive '${directive.name}'`,
     path: `@${directive.name}`,
+    meta: {
+      directiveName: directive.name,
+      addedDirectiveArgumentName: arg.name,
+      addedDirectiveArgumentType: arg.type.toString(),
+    },
   };
 }
 
 export function directiveArgumentRemoved(
   directive: GraphQLDirective,
   arg: GraphQLArgument,
-): Change {
+): Change<ChangeType.DirectiveArgumentRemoved> {
   return {
     criticality: {
       level: CriticalityLevel.Breaking,
@@ -87,6 +143,11 @@ export function directiveArgumentRemoved(
     type: ChangeType.DirectiveArgumentRemoved,
     message: `Argument '${arg.name}' was removed from directive '${directive.name}'`,
     path: `@${directive.name}.${arg.name}`,
+    meta: {
+      directiveName: directive.name,
+      removedDirectiveArgumentName: arg.name,
+      removedDirectiveArgumentType: arg.type.toString(),
+    },
   };
 }
 
@@ -94,7 +155,7 @@ export function directiveArgumentDescriptionChanged(
   directive: GraphQLDirective,
   oldArg: GraphQLArgument,
   newArg: GraphQLArgument,
-): Change {
+): Change<ChangeType.DirectiveArgumentDescriptionChanged> {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
@@ -102,6 +163,12 @@ export function directiveArgumentDescriptionChanged(
     type: ChangeType.DirectiveArgumentDescriptionChanged,
     message: `Description for argument '${oldArg.name}' on directive '${directive.name}' changed from '${oldArg.description}' to '${newArg.description}'`,
     path: `@${directive.name}.${oldArg.name}`,
+    meta: {
+      directiveName: directive.name,
+      directiveArgumentName: oldArg.name,
+      oldDirectiveArgumentDescription: oldArg.description ?? null,
+      newDirectiveArgumentDescription: newArg.description ?? null,
+    },
   };
 }
 
@@ -109,7 +176,7 @@ export function directiveArgumentDefaultValueChanged(
   directive: GraphQLDirective,
   oldArg: GraphQLArgument,
   newArg: GraphQLArgument,
-): Change {
+): Change<ChangeType.DirectiveArgumentDefaultValueChanged> {
   return {
     criticality: {
       level: CriticalityLevel.Dangerous,
@@ -122,6 +189,12 @@ export function directiveArgumentDefaultValueChanged(
         ? `Default value '${newArg.defaultValue}' was added to argument '${newArg.name}' on directive '${directive.name}'`
         : `Default value for argument '${oldArg.name}' on directive '${directive.name}' changed from '${oldArg.defaultValue}' to '${newArg.defaultValue}'`,
     path: `@${directive.name}.${oldArg.name}`,
+    meta: {
+      directiveName: directive.name,
+      directiveArgumentName: oldArg.name,
+      oldDirectiveArgumentDefaultValue: safeString(oldArg.defaultValue) ?? null,
+      newDirectiveArgumentDefaultValue: safeString(newArg.defaultValue) ?? null,
+    },
   };
 }
 
@@ -129,7 +202,7 @@ export function directiveArgumentTypeChanged(
   directive: GraphQLDirective,
   oldArg: GraphQLArgument,
   newArg: GraphQLArgument,
-): Change {
+): Change<ChangeType.DirectiveArgumentTypeChanged> {
   return {
     criticality: safeChangeForInputValue(oldArg.type, newArg.type)
       ? {
@@ -142,5 +215,11 @@ export function directiveArgumentTypeChanged(
     type: ChangeType.DirectiveArgumentTypeChanged,
     message: `Type for argument '${oldArg.name}' on directive '${directive.name}' changed from '${oldArg.type}' to '${newArg.type}'`,
     path: `@${directive.name}.${oldArg.name}`,
+    meta: {
+      directiveName: directive.name,
+      directiveArgumentName: oldArg.name,
+      oldDirectiveArgumentType: oldArg.type.toString(),
+      newDirectiveArgumentType: newArg.type.toString(),
+    },
   };
 }

--- a/packages/core/src/diff/changes/directive.ts
+++ b/packages/core/src/diff/changes/directive.ts
@@ -6,149 +6,250 @@ import {
   ChangeType,
   CriticalityLevel,
   DirectiveAdded,
+  DirectiveArgumentAdded,
+  DirectiveArgumentDefaultValueChanged,
+  DirectiveArgumentDescriptionChanged,
+  DirectiveArgumentRemoved,
+  DirectiveArgumentTypeChanged,
   DirectiveDescriptionChanged,
+  DirectiveLocationAdded,
+  DirectiveLocationRemoved,
   DirectiveRemoved,
 } from './change';
 
-function buildDirectiveRemovedMessage(directive: DirectiveRemoved): string {
-  return `Directive '${directive.meta.removedDirectiveName}' was removed`;
+function buildDirectiveRemovedMessage(args: DirectiveRemoved['meta']): string {
+  return `Directive '${args.removedDirectiveName}' was removed`;
 }
 
-export function directiveRemoved(directive: GraphQLDirective): Change<ChangeType.DirectiveRemoved> {
+const directiveRemovedCriticalityBreakingReason = `A directive could be in use of a client application. Removing it could break the client application.`;
+
+export function directiveRemovedFromMeta(args: DirectiveRemoved) {
   return {
     criticality: {
       level: CriticalityLevel.Breaking,
+      reason: directiveRemovedCriticalityBreakingReason,
     },
     type: ChangeType.DirectiveRemoved,
-    get message() {
-      return buildDirectiveRemovedMessage(this);
-    },
-    path: `@${directive.name}`,
+    message: buildDirectiveRemovedMessage(args.meta),
+    path: `@${args.meta.removedDirectiveName}`,
+    meta: args.meta,
+  } as const;
+}
+
+export function directiveRemoved(directive: GraphQLDirective): Change<ChangeType.DirectiveRemoved> {
+  return directiveRemovedFromMeta({
+    type: ChangeType.DirectiveRemoved,
     meta: {
       removedDirectiveName: directive.name,
     },
-  };
+  });
 }
 
-function buildDirectiveAddedMessage(directive: DirectiveAdded): string {
-  return `Directive '${directive.meta.addedDirectiveName}' was added`;
+function buildDirectiveAddedMessage(args: DirectiveAdded['meta']): string {
+  return `Directive '${args.addedDirectiveName}' was added`;
 }
 
-export function directiveAdded(directive: GraphQLDirective): Change<ChangeType.DirectiveAdded> {
+export function directiveAddedFromMeta(args: DirectiveAdded) {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.DirectiveAdded,
-    get message() {
-      return buildDirectiveAddedMessage(this);
-    },
-    path: `@${directive.name}`,
+    message: buildDirectiveAddedMessage(args.meta),
+    path: `@${args.meta.addedDirectiveName}`,
+    meta: args.meta,
+  } as const;
+}
+
+export function directiveAdded(directive: GraphQLDirective): Change<ChangeType.DirectiveAdded> {
+  return directiveAddedFromMeta({
+    type: ChangeType.DirectiveAdded,
     meta: {
       addedDirectiveName: directive.name,
     },
-  };
+  });
 }
 
-function buildDirectiveDescriptionChangedMessage(directive: DirectiveDescriptionChanged): string {
-  return `Directive '${directive.meta.directiveName}' description changed from '${
-    directive.meta.oldDirectiveDescription ?? 'undefined'
-  }' to '${directive.meta.newDirectiveDescription ?? 'undefined'}'`;
+function buildDirectiveDescriptionChangedMessage(
+  args: DirectiveDescriptionChanged['meta'],
+): string {
+  return `Directive '${args.directiveName}' description changed from '${
+    args.oldDirectiveDescription ?? 'undefined'
+  }' to '${args.newDirectiveDescription ?? 'undefined'}'`;
+}
+
+export function directiveDescriptionChangedFromMeta(args: DirectiveDescriptionChanged) {
+  return {
+    criticality: {
+      level: CriticalityLevel.NonBreaking,
+    },
+    type: ChangeType.DirectiveDescriptionChanged,
+    message: buildDirectiveDescriptionChangedMessage(args.meta),
+    path: `@${args.meta.directiveName}`,
+    meta: args.meta,
+  } as const;
 }
 
 export function directiveDescriptionChanged(
   oldDirective: GraphQLDirective,
   newDirective: GraphQLDirective,
 ): Change<ChangeType.DirectiveDescriptionChanged> {
-  return {
-    criticality: {
-      level: CriticalityLevel.NonBreaking,
-    },
+  return directiveDescriptionChangedFromMeta({
     type: ChangeType.DirectiveDescriptionChanged,
-    get message() {
-      return buildDirectiveDescriptionChangedMessage(this);
-    },
-    path: `@${oldDirective.name}`,
     meta: {
       directiveName: oldDirective.name,
       oldDirectiveDescription: oldDirective.description ?? null,
       newDirectiveDescription: newDirective.description ?? null,
     },
-  };
+  });
+}
+
+function buildDirectiveLocationAddedMessage(args: DirectiveLocationAdded['meta']): string {
+  return `Location '${args.addedDirectiveLocation}' was added to directive '${args.directiveName}'`;
+}
+
+export function directiveLocationAddedFromMeta(args: DirectiveLocationAdded) {
+  return {
+    criticality: {
+      level: CriticalityLevel.NonBreaking,
+    },
+    type: ChangeType.DirectiveLocationAdded,
+    message: buildDirectiveLocationAddedMessage(args.meta),
+    path: `@${args.meta.directiveName}`,
+    meta: args.meta,
+  } as const;
 }
 
 export function directiveLocationAdded(
   directive: GraphQLDirective,
   location: DirectiveLocationEnum,
 ): Change<ChangeType.DirectiveLocationAdded> {
-  return {
-    criticality: {
-      level: CriticalityLevel.NonBreaking,
-    },
+  return directiveLocationAddedFromMeta({
     type: ChangeType.DirectiveLocationAdded,
-    message: `Location '${location}' was added to directive '${directive.name}'`,
-    path: `@${directive.name}`,
     meta: {
       directiveName: directive.name,
       addedDirectiveLocation: location.toString(),
     },
-  };
+  });
+}
+
+function buildDirectiveLocationRemovedMessage(args: DirectiveLocationRemoved['meta']): string {
+  return `Location '${args.removedDirectiveLocation}' was removed from directive '${args.directiveName}'`;
+}
+
+const directiveLocationRemovedBreakingReason = `A directive could be in use of a client application. Removing it could break the client application.`;
+
+export function directiveLocationRemovedFromMeta(args: DirectiveLocationRemoved) {
+  return {
+    criticality: {
+      level: CriticalityLevel.Breaking,
+      reason: directiveLocationRemovedBreakingReason,
+    },
+    type: ChangeType.DirectiveLocationRemoved,
+    message: buildDirectiveLocationRemovedMessage(args.meta),
+    path: `@${args.meta.directiveName}`,
+    meta: args.meta,
+  } as const;
 }
 
 export function directiveLocationRemoved(
   directive: GraphQLDirective,
   location: DirectiveLocationEnum,
 ): Change<ChangeType.DirectiveLocationRemoved> {
-  return {
-    criticality: {
-      level: CriticalityLevel.Breaking,
-    },
+  return directiveLocationRemovedFromMeta({
     type: ChangeType.DirectiveLocationRemoved,
-    message: `Location '${location}' was removed from directive '${directive.name}'`,
-    path: `@${directive.name}`,
     meta: {
       directiveName: directive.name,
       removedDirectiveLocation: location.toString(),
     },
-  };
+  });
+}
+
+const directiveArgumentAddedBreakingReason = `A directive could be in use of a client application. Adding a non-nullable argument will break those clients.`;
+const directiveArgumentNonBreakingReason = `A directive could be in use of a client application. Adding a non-nullable argument will break those clients.`;
+
+export function directiveArgumentAddedFromMeta(args: DirectiveArgumentAdded) {
+  return {
+    criticality: args.meta.addedDirectiveArgumentTypeIsNonNull
+      ? {
+          level: CriticalityLevel.Breaking,
+          reason: directiveArgumentAddedBreakingReason,
+        }
+      : {
+          level: CriticalityLevel.NonBreaking,
+          reason: directiveArgumentNonBreakingReason,
+        },
+    type: ChangeType.DirectiveArgumentAdded,
+    message: `Argument '${args.meta.addedDirectiveArgumentName}' was added to directive '${args.meta.directiveName}'`,
+    path: `@${args.meta.directiveName}`,
+    meta: args.meta,
+  } as const;
 }
 
 export function directiveArgumentAdded(
   directive: GraphQLDirective,
   arg: GraphQLArgument,
 ): Change<ChangeType.DirectiveArgumentAdded> {
-  return {
-    criticality: {
-      level: isNonNullType(arg.type) ? CriticalityLevel.Breaking : CriticalityLevel.NonBreaking,
-    },
+  return directiveArgumentAddedFromMeta({
     type: ChangeType.DirectiveArgumentAdded,
-    message: `Argument '${arg.name}' was added to directive '${directive.name}'`,
-    path: `@${directive.name}`,
     meta: {
       directiveName: directive.name,
       addedDirectiveArgumentName: arg.name,
-      addedDirectiveArgumentType: arg.type.toString(),
+      addedDirectiveArgumentTypeIsNonNull: isNonNullType(arg.type),
     },
-  };
+  });
+}
+
+function buildDirectiveArgumentRemovedMessage(args: DirectiveArgumentRemoved['meta']): string {
+  return `Argument '${args.removedDirectiveArgumentName}' was removed from directive '${args.directiveName}'`;
+}
+
+const directiveArgumentRemovedBreakingReason = `A directive argument could be in use of a client application. Removing the argument can break client applications.`;
+
+export function directiveArgumentRemovedFromMeta(args: DirectiveArgumentRemoved) {
+  return {
+    criticality: {
+      level: CriticalityLevel.Breaking,
+      reason: directiveArgumentRemovedBreakingReason,
+    },
+    type: ChangeType.DirectiveArgumentRemoved,
+    message: buildDirectiveArgumentRemovedMessage(args.meta),
+    path: `@${args.meta.directiveName}.${args.meta.removedDirectiveArgumentName}`,
+    meta: args.meta,
+  } as const;
 }
 
 export function directiveArgumentRemoved(
   directive: GraphQLDirective,
   arg: GraphQLArgument,
 ): Change<ChangeType.DirectiveArgumentRemoved> {
-  return {
-    criticality: {
-      level: CriticalityLevel.Breaking,
-    },
+  return directiveArgumentRemovedFromMeta({
     type: ChangeType.DirectiveArgumentRemoved,
-    message: `Argument '${arg.name}' was removed from directive '${directive.name}'`,
-    path: `@${directive.name}.${arg.name}`,
     meta: {
       directiveName: directive.name,
       removedDirectiveArgumentName: arg.name,
-      removedDirectiveArgumentType: arg.type.toString(),
     },
-  };
+  });
+}
+
+function buildDirectiveArgumentDescriptionChangedMessage(
+  args: DirectiveArgumentDescriptionChanged['meta'],
+): string {
+  return `Description for argument '${args.directiveArgumentName}' on directive '${args.directiveName}' changed from '${args.oldDirectiveArgumentDescription}' to '${args.newDirectiveArgumentDescription}'`;
+}
+
+export function directiveArgumentDescriptionChangedFromMeta(
+  args: DirectiveArgumentDescriptionChanged,
+) {
+  return {
+    criticality: {
+      level: CriticalityLevel.NonBreaking,
+    },
+    type: ChangeType.DirectiveArgumentDescriptionChanged,
+    message: buildDirectiveArgumentDescriptionChangedMessage(args.meta),
+    path: `@${args.meta.directiveName}.${args.meta.directiveArgumentName}`,
+    meta: args.meta,
+  } as const;
 }
 
 export function directiveArgumentDescriptionChanged(
@@ -156,20 +257,41 @@ export function directiveArgumentDescriptionChanged(
   oldArg: GraphQLArgument,
   newArg: GraphQLArgument,
 ): Change<ChangeType.DirectiveArgumentDescriptionChanged> {
-  return {
-    criticality: {
-      level: CriticalityLevel.NonBreaking,
-    },
+  return directiveArgumentDescriptionChangedFromMeta({
     type: ChangeType.DirectiveArgumentDescriptionChanged,
-    message: `Description for argument '${oldArg.name}' on directive '${directive.name}' changed from '${oldArg.description}' to '${newArg.description}'`,
-    path: `@${directive.name}.${oldArg.name}`,
     meta: {
       directiveName: directive.name,
       directiveArgumentName: oldArg.name,
       oldDirectiveArgumentDescription: oldArg.description ?? null,
       newDirectiveArgumentDescription: newArg.description ?? null,
     },
-  };
+  });
+}
+
+function buildDirectiveArgumentDefaultValueChanged(
+  args: DirectiveArgumentDefaultValueChanged['meta'],
+): string {
+  return args.oldDirectiveArgumentDefaultValue === undefined
+    ? `Default value '${args.newDirectiveArgumentDefaultValue}' was added to argument '${args.directiveArgumentName}' on directive '${args.directiveName}'`
+    : `Default value for argument '${args.directiveArgumentName}' on directive '${args.directiveName}' changed from '${args.oldDirectiveArgumentDefaultValue}' to '${args.newDirectiveArgumentDefaultValue}'`;
+}
+
+const directiveArgumentDefaultValueChangedDangerousReason =
+  'Changing the default value for an argument may change the runtime behaviour of a field if it was never provided.';
+
+export function directiveArgumentDefaultValueChangedFromMeta(
+  args: DirectiveArgumentDefaultValueChanged,
+) {
+  return {
+    criticality: {
+      level: CriticalityLevel.Dangerous,
+      reason: directiveArgumentDefaultValueChangedDangerousReason,
+    },
+    type: ChangeType.DirectiveArgumentDefaultValueChanged,
+    message: buildDirectiveArgumentDefaultValueChanged(args.meta),
+    path: `@${args.meta.directiveName}.${args.meta.directiveArgumentName}`,
+    meta: args.meta,
+  } as const;
 }
 
 export function directiveArgumentDefaultValueChanged(
@@ -177,25 +299,41 @@ export function directiveArgumentDefaultValueChanged(
   oldArg: GraphQLArgument,
   newArg: GraphQLArgument,
 ): Change<ChangeType.DirectiveArgumentDefaultValueChanged> {
-  return {
-    criticality: {
-      level: CriticalityLevel.Dangerous,
-      reason:
-        'Changing the default value for an argument may change the runtime behaviour of a field if it was never provided.',
-    },
+  return directiveArgumentDefaultValueChangedFromMeta({
     type: ChangeType.DirectiveArgumentDefaultValueChanged,
-    message:
-      typeof oldArg.defaultValue === 'undefined'
-        ? `Default value '${newArg.defaultValue}' was added to argument '${newArg.name}' on directive '${directive.name}'`
-        : `Default value for argument '${oldArg.name}' on directive '${directive.name}' changed from '${oldArg.defaultValue}' to '${newArg.defaultValue}'`,
-    path: `@${directive.name}.${oldArg.name}`,
     meta: {
       directiveName: directive.name,
       directiveArgumentName: oldArg.name,
-      oldDirectiveArgumentDefaultValue: safeString(oldArg.defaultValue) ?? null,
-      newDirectiveArgumentDefaultValue: safeString(newArg.defaultValue) ?? null,
+      oldDirectiveArgumentDefaultValue:
+        oldArg.defaultValue === undefined ? undefined : safeString(oldArg.defaultValue),
+      newDirectiveArgumentDefaultValue:
+        newArg.defaultValue === undefined ? undefined : safeString(newArg.defaultValue),
     },
-  };
+  });
+}
+
+function buildDirectiveArgumentTypeChangedMessage(args: DirectiveArgumentTypeChanged): string {
+  return `Type for argument '${args.meta.directiveArgumentName}' on directive '${args.meta.directiveName}' changed from '${args.meta.oldDirectiveArgumentType}' to '${args.meta.newDirectiveArgumentType}'`;
+}
+
+const directiveArgumentTypeChangedNonBreakingReason =
+  'Changing an input field from non-null to null is considered non-breaking.';
+
+export function directiveArgumentTypeChangedFromMeta(args: DirectiveArgumentTypeChanged) {
+  return {
+    criticality: args.meta.isSafeDirectiveArgumentTypeChange
+      ? {
+          level: CriticalityLevel.NonBreaking,
+          reason: directiveArgumentTypeChangedNonBreakingReason,
+        }
+      : {
+          level: CriticalityLevel.Breaking,
+        },
+    type: ChangeType.DirectiveArgumentTypeChanged,
+    message: buildDirectiveArgumentTypeChangedMessage(args),
+    path: `@${args.meta.directiveName}.${args.meta.directiveArgumentName}`,
+    meta: args.meta,
+  } as const;
 }
 
 export function directiveArgumentTypeChanged(
@@ -203,23 +341,14 @@ export function directiveArgumentTypeChanged(
   oldArg: GraphQLArgument,
   newArg: GraphQLArgument,
 ): Change<ChangeType.DirectiveArgumentTypeChanged> {
-  return {
-    criticality: safeChangeForInputValue(oldArg.type, newArg.type)
-      ? {
-          level: CriticalityLevel.NonBreaking,
-          reason: 'Changing an input field from non-null to null is considered non-breaking.',
-        }
-      : {
-          level: CriticalityLevel.Breaking,
-        },
+  return directiveArgumentTypeChangedFromMeta({
     type: ChangeType.DirectiveArgumentTypeChanged,
-    message: `Type for argument '${oldArg.name}' on directive '${directive.name}' changed from '${oldArg.type}' to '${newArg.type}'`,
-    path: `@${directive.name}.${oldArg.name}`,
     meta: {
       directiveName: directive.name,
       directiveArgumentName: oldArg.name,
       oldDirectiveArgumentType: oldArg.type.toString(),
       newDirectiveArgumentType: newArg.type.toString(),
+      isSafeDirectiveArgumentTypeChange: safeChangeForInputValue(oldArg.type, newArg.type),
     },
-  };
+  });
 }

--- a/packages/core/src/diff/changes/enum.ts
+++ b/packages/core/src/diff/changes/enum.ts
@@ -1,92 +1,179 @@
 import { GraphQLEnumType, GraphQLEnumValue } from 'graphql';
 import { isDeprecated } from '../../utils/is-deprecated';
-import { Change, ChangeType, CriticalityLevel } from './change';
+import {
+  Change,
+  ChangeType,
+  CriticalityLevel,
+  EnumValueAdded,
+  EnumValueDeprecationReasonAdded,
+  EnumValueDeprecationReasonChanged,
+  EnumValueDeprecationReasonRemoved,
+  EnumValueDescriptionChanged,
+  EnumValueRemoved,
+} from './change';
 
-export function enumValueRemoved(oldEnum: GraphQLEnumType, value: GraphQLEnumValue): Change {
+function buildEnumValueRemovedMessage(args: EnumValueRemoved) {
+  return `Enum value '${args.meta.removedEnumValueName}' ${
+    args.meta.isEnumValueDeprecated ? '(deprecated) ' : ''
+  }was removed from enum '${args.meta.enumName}'`;
+}
+
+export function enumValueRemoved(
+  oldEnum: GraphQLEnumType,
+  value: GraphQLEnumValue,
+): Change<ChangeType.EnumValueRemoved> {
   return {
     criticality: {
       level: CriticalityLevel.Breaking,
       reason: `Removing an enum value will cause existing queries that use this enum value to error.`,
     },
     type: ChangeType.EnumValueRemoved,
-    message: `Enum value '${value.name}' ${
-      isDeprecated(value) ? '(deprecated) ' : ''
-    }was removed from enum '${oldEnum.name}'`,
+    get message() {
+      return buildEnumValueRemovedMessage(this);
+    },
     path: [oldEnum.name, value.name].join('.'),
+    meta: {
+      enumName: oldEnum.name,
+      removedEnumValueName: value.name,
+      isEnumValueDeprecated: isDeprecated(value),
+    },
   };
 }
 
-export function enumValueAdded(newEnum: GraphQLEnumType, value: GraphQLEnumValue): Change {
+function buildEnumValueAddedMessage(args: EnumValueAdded) {
+  return `Enum value '${args.meta.addedEnumValueName}' was added to enum '${args.meta.enumName}'`;
+}
+
+export function enumValueAdded(
+  newEnum: GraphQLEnumType,
+  value: GraphQLEnumValue,
+): Change<ChangeType.EnumValueAdded> {
   return {
     criticality: {
       level: CriticalityLevel.Dangerous,
       reason: `Adding an enum value may break existing clients that were not programming defensively against an added case when querying an enum.`,
     },
     type: ChangeType.EnumValueAdded,
-    message: `Enum value '${value.name}' was added to enum '${newEnum.name}'`,
+    get message() {
+      return buildEnumValueAddedMessage(this);
+    },
     path: [newEnum.name, value.name].join('.'),
+    meta: {
+      enumName: newEnum.name,
+      addedEnumValueName: value.name,
+    },
   };
+}
+
+function buildEnumValueDescriptionChangedMessage(args: EnumValueDescriptionChanged) {
+  return args.meta.oldEnumValueDescription === null
+    ? `Description '${args.meta.newEnumValueDescription ?? 'undefined'}' was added to enum value '${
+        args.meta.enumName
+      }.${args.meta.enumValueName}'`
+    : `Description for enum value '${args.meta.enumName}.${
+        args.meta.enumValueName
+      }' changed from '${args.meta.oldEnumValueDescription ?? 'undefined'}' to '${
+        args.meta.newEnumValueDescription ?? 'undefined'
+      }'`;
 }
 
 export function enumValueDescriptionChanged(
   newEnum: GraphQLEnumType,
   oldValue: GraphQLEnumValue,
   newValue: GraphQLEnumValue,
-): Change {
+): Change<ChangeType.EnumValueDescriptionChanged> {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.EnumValueDescriptionChanged,
-    message:
-      typeof oldValue.description === 'undefined'
-        ? `Description '${newValue.description}' was added to enum value '${newEnum.name}.${newValue.name}'`
-        : `Description for enum value '${newEnum.name}.${newValue.name}' changed from '${oldValue.description}' to '${newValue.description}'`,
+    get message() {
+      return buildEnumValueDescriptionChangedMessage(this);
+    },
     path: [newEnum.name, oldValue.name].join('.'),
+    meta: {
+      enumName: newEnum.name,
+      enumValueName: oldValue.name,
+      oldEnumValueDescription: oldValue.description ?? null,
+      newEnumValueDescription: newValue.description ?? null,
+    },
   };
+}
+
+function buildEnumValueDeprecationChangedMessage(args: EnumValueDeprecationReasonChanged) {
+  return `Enum value '${args.meta.enumName}.${args.meta.enumValueName}' deprecation reason changed from '${args.meta.oldEnumValueDeprecationReason}' to '${args.meta.newEnumValueDeprecationReason}'`;
 }
 
 export function enumValueDeprecationReasonChanged(
   newEnum: GraphQLEnumType,
   oldValue: GraphQLEnumValue,
   newValue: GraphQLEnumValue,
-): Change {
+): Change<ChangeType.EnumValueDeprecationReasonChanged> {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.EnumValueDeprecationReasonChanged,
-    message: `Enum value '${newEnum.name}.${newValue.name}' deprecation reason changed from '${oldValue.deprecationReason}' to '${newValue.deprecationReason}'`,
+    get message() {
+      return buildEnumValueDeprecationChangedMessage(this);
+    },
     path: [newEnum.name, oldValue.name].join('.'),
+    meta: {
+      enumName: newEnum.name,
+      enumValueName: oldValue.name,
+      oldEnumValueDeprecationReason: oldValue.deprecationReason ?? '',
+      newEnumValueDeprecationReason: newValue.deprecationReason ?? '',
+    },
   };
+}
+
+function buildEnumValueDeprecationReasonAddedMessage(args: EnumValueDeprecationReasonAdded) {
+  return `Enum value '${args.meta.enumName}.${args.meta.enumValueName}' was deprecated with reason '${args.meta.addedValueDeprecationReason}'`;
 }
 
 export function enumValueDeprecationReasonAdded(
   newEnum: GraphQLEnumType,
   oldValue: GraphQLEnumValue,
   newValue: GraphQLEnumValue,
-): Change {
+): Change<ChangeType.EnumValueDeprecationReasonAdded> {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.EnumValueDeprecationReasonAdded,
-    message: `Enum value '${newEnum.name}.${newValue.name}' was deprecated with reason '${newValue.deprecationReason}'`,
+    get message() {
+      return buildEnumValueDeprecationReasonAddedMessage(this);
+    },
     path: [newEnum.name, oldValue.name].join('.'),
+    meta: {
+      enumName: newEnum.name,
+      enumValueName: oldValue.name,
+      addedValueDeprecationReason: newValue.deprecationReason ?? '',
+    },
   };
+}
+
+function buildEnumValueDeprecationReasonRemovedMessage(args: EnumValueDeprecationReasonRemoved) {
+  return `Deprecation reason was removed from enum value '${args.meta.enumName}.${args.meta.enumValueName}'`;
 }
 
 export function enumValueDeprecationReasonRemoved(
   newEnum: GraphQLEnumType,
   oldValue: GraphQLEnumValue,
-  newValue: GraphQLEnumValue,
-): Change {
+  _newValue: GraphQLEnumValue,
+): Change<ChangeType.EnumValueDeprecationReasonRemoved> {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.EnumValueDeprecationReasonRemoved,
-    message: `Deprecation reason was removed from enum value '${newEnum.name}.${newValue.name}'`,
-    path: [newEnum.name, oldValue.name].join('.'),
+    get message() {
+      return buildEnumValueDeprecationReasonRemovedMessage(this);
+    },
+    meta: {
+      enumName: newEnum.name,
+      enumValueName: oldValue.name,
+      removedEnumValueDeprecationReason: oldValue.deprecationReason ?? '',
+    },
   };
 }

--- a/packages/core/src/diff/changes/input.ts
+++ b/packages/core/src/diff/changes/input.ts
@@ -2,9 +2,29 @@ import { GraphQLInputField, GraphQLInputObjectType, isNonNullType } from 'graphq
 import { safeChangeForInputValue } from '../../utils/graphql';
 import { isDeprecated } from '../../utils/is-deprecated';
 import { safeString } from '../../utils/string';
-import { Change, ChangeType, CriticalityLevel } from './change';
+import {
+  Change,
+  ChangeType,
+  CriticalityLevel,
+  InputFieldAdded,
+  InputFieldDefaultValueChanged,
+  InputFieldDescriptionAdded,
+  InputFieldDescriptionChanged,
+  InputFieldDescriptionRemoved,
+  InputFieldRemoved,
+  InputFieldTypeChanged,
+} from './change';
 
-export function inputFieldRemoved(input: GraphQLInputObjectType, field: GraphQLInputField): Change {
+function buildInputFieldRemovedMessage(args: InputFieldRemoved) {
+  return `Input field '${args.meta.removedFieldName}' ${
+    args.meta.isInputFieldDeprecated ? '(deprecated) ' : ''
+  }was removed from input object type '${args.meta.inputName}'`;
+}
+
+export function inputFieldRemoved(
+  input: GraphQLInputObjectType,
+  field: GraphQLInputField,
+): Change<ChangeType.InputFieldRemoved> {
   return {
     criticality: {
       level: CriticalityLevel.Breaking,
@@ -12,14 +32,26 @@ export function inputFieldRemoved(input: GraphQLInputObjectType, field: GraphQLI
         'Removing an input field will cause existing queries that use this input field to error.',
     },
     type: ChangeType.InputFieldRemoved,
-    message: `Input field '${field.name}' ${
-      isDeprecated(field) ? '(deprecated) ' : ''
-    }was removed from input object type '${input.name}'`,
+    get message() {
+      return buildInputFieldRemovedMessage(this);
+    },
     path: [input.name, field.name].join('.'),
+    meta: {
+      inputName: input.name,
+      removedFieldName: field.name,
+      isInputFieldDeprecated: isDeprecated(field),
+    },
   };
 }
 
-export function inputFieldAdded(input: GraphQLInputObjectType, field: GraphQLInputField): Change {
+export function buildInputFieldAddedMessage(args: InputFieldAdded) {
+  return `Input field '${args.meta.addedInputFieldName}' was added to input object type '${args.meta.inputName}'`;
+}
+
+export function inputFieldAdded(
+  input: GraphQLInputObjectType,
+  field: GraphQLInputField,
+): Change<ChangeType.InputFieldAdded> {
   return {
     criticality: isNonNullType(field.type)
       ? {
@@ -31,59 +63,102 @@ export function inputFieldAdded(input: GraphQLInputObjectType, field: GraphQLInp
           level: CriticalityLevel.Dangerous,
         },
     type: ChangeType.InputFieldAdded,
-    message: `Input field '${field.name}' was added to input object type '${input.name}'`,
+    get message() {
+      return buildInputFieldAddedMessage(this);
+    },
     path: [input.name, field.name].join('.'),
+    meta: {
+      inputName: input.name,
+      addedInputFieldName: field.name,
+    },
   };
+}
+
+function buildInputFieldDescriptionAddedMessage(args: InputFieldDescriptionAdded) {
+  return `Input field '${args.meta.inputName}.${args.meta.inputFieldName}' has description '${args.meta.addedInputFieldDescription}'`;
 }
 
 export function inputFieldDescriptionAdded(
   type: GraphQLInputObjectType,
   field: GraphQLInputField,
-): Change {
+): Change<ChangeType.InputFieldDescriptionAdded> {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.InputFieldDescriptionAdded,
-    message: `Input field '${type.name}.${field.name}' has description '${field.description}'`,
+    get message() {
+      return buildInputFieldDescriptionAddedMessage(this);
+    },
     path: [type.name, field.name].join('.'),
+    meta: {
+      inputName: type.name,
+      inputFieldName: field.name,
+      addedInputFieldDescription: safeString(field.description),
+    },
   };
+}
+
+function buildInputFieldDescriptionRemovedMessage(args: InputFieldDescriptionRemoved) {
+  return `Description was removed from input field '${args.meta.inputName}.${args.meta.inputFieldName}'`;
 }
 
 export function inputFieldDescriptionRemoved(
   type: GraphQLInputObjectType,
   field: GraphQLInputField,
-): Change {
+): Change<ChangeType.InputFieldDescriptionRemoved> {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.InputFieldDescriptionRemoved,
-    message: `Description was removed from input field '${type.name}.${field.name}'`,
+    get message() {
+      return buildInputFieldDescriptionRemovedMessage(this);
+    },
     path: [type.name, field.name].join('.'),
+    meta: {
+      inputName: type.name,
+      inputFieldName: field.name,
+    },
   };
+}
+
+function buildInputFieldDescriptionChangedMessage(args: InputFieldDescriptionChanged) {
+  return `Input field '${args.meta.inputName}.${args.meta.inputFieldName}' description changed from '${args.meta.oldInputFieldDescription}' to '${args.meta.newInputFieldDescription}'`;
 }
 
 export function inputFieldDescriptionChanged(
   input: GraphQLInputObjectType,
   oldField: GraphQLInputField,
   newField: GraphQLInputField,
-): Change {
+): Change<ChangeType.InputFieldDescriptionChanged> {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.InputFieldDescriptionChanged,
-    message: `Input field '${input.name}.${oldField.name}' description changed from '${oldField.description}' to '${newField.description}'`,
+    get message() {
+      return buildInputFieldDescriptionChangedMessage(this);
+    },
     path: [input.name, oldField.name].join('.'),
+    meta: {
+      inputName: input.name,
+      inputFieldName: oldField.name,
+      oldInputFieldDescription: oldField.description ?? '',
+      newInputFieldDescription: newField.description ?? '',
+    },
   };
+}
+
+function buildInputFieldDefaultValueChangedMessage(args: InputFieldDefaultValueChanged) {
+  return `Input field '${args.meta.inputName}.${args.meta.inputFieldName}' default value changed from '${args.meta.oldDefaultValue}' to '${args.meta.newDefaultValue}'`;
 }
 
 export function inputFieldDefaultValueChanged(
   input: GraphQLInputObjectType,
   oldField: GraphQLInputField,
   newField: GraphQLInputField,
-): Change {
+): Change<ChangeType.InputFieldDefaultValueChanged> {
   return {
     criticality: {
       level: CriticalityLevel.Dangerous,
@@ -91,18 +166,28 @@ export function inputFieldDefaultValueChanged(
         'Changing the default value for an argument may change the runtime behavior of a field if it was never provided.',
     },
     type: ChangeType.InputFieldDefaultValueChanged,
-    message: `Input field '${input.name}.${oldField.name}' default value changed from '${safeString(
-      oldField.defaultValue,
-    )}' to '${safeString(newField.defaultValue)}'`,
+    get message() {
+      return buildInputFieldDefaultValueChangedMessage(this);
+    },
     path: [input.name, oldField.name].join('.'),
+    meta: {
+      inputName: input.name,
+      inputFieldName: oldField.name,
+      newDefaultValue: newField.defaultValue ? safeString(newField.defaultValue) : undefined,
+      oldDefaultValue: oldField.defaultValue ? safeString(oldField.defaultValue) : undefined,
+    },
   };
+}
+
+function buildInputFieldTypeChangedMessage(args: InputFieldTypeChanged) {
+  return `Input field '${args.meta.inputName}.${args.meta.inputFieldName}' changed type from '${args.meta.oldInputFieldType}' to '${args.meta.newInputFieldType}'`;
 }
 
 export function inputFieldTypeChanged(
   input: GraphQLInputObjectType,
   oldField: GraphQLInputField,
   newField: GraphQLInputField,
-): Change {
+): Change<ChangeType.InputFieldTypeChanged> {
   return {
     criticality: safeChangeForInputValue(oldField.type, newField.type)
       ? {
@@ -115,9 +200,15 @@ export function inputFieldTypeChanged(
             'Changing the type of an input field can cause existing queries that use this field to error.',
         },
     type: ChangeType.InputFieldTypeChanged,
-    message: `Input field '${input.name}.${
-      oldField.name
-    }' changed type from '${oldField.type.toString()}' to '${newField.type.toString()}'`,
+    get message() {
+      return buildInputFieldTypeChangedMessage(this);
+    },
     path: [input.name, oldField.name].join('.'),
+    meta: {
+      inputName: input.name,
+      inputFieldName: oldField.name,
+      oldInputFieldType: oldField.type.toString(),
+      newInputFieldType: newField.type.toString(),
+    },
   };
 }

--- a/packages/core/src/diff/changes/object.ts
+++ b/packages/core/src/diff/changes/object.ts
@@ -1,10 +1,20 @@
 import { GraphQLInterfaceType, GraphQLObjectType } from 'graphql';
-import { Change, ChangeType, CriticalityLevel } from './change';
+import {
+  Change,
+  ChangeType,
+  CriticalityLevel,
+  ObjectTypeInterfaceAdded,
+  ObjectTypeInterfaceRemoved,
+} from './change';
+
+function buildObjectTypeInterfaceAddedMessage(args: ObjectTypeInterfaceAdded) {
+  return `'${args.meta.objectTypeName}' object implements '${args.meta.addedInterfaceName}' interface`;
+}
 
 export function objectTypeInterfaceAdded(
   iface: GraphQLInterfaceType,
   type: GraphQLObjectType,
-): Change {
+): Change<ChangeType.ObjectTypeInterfaceAdded> {
   return {
     criticality: {
       level: CriticalityLevel.Dangerous,
@@ -12,15 +22,25 @@ export function objectTypeInterfaceAdded(
         'Adding an interface to an object type may break existing clients that were not programming defensively against a new possible type.',
     },
     type: ChangeType.ObjectTypeInterfaceAdded,
-    message: `'${type.name}' object implements '${iface.name}' interface`,
+    get message() {
+      return buildObjectTypeInterfaceAddedMessage(this);
+    },
     path: type.name,
+    meta: {
+      objectTypeName: type.name,
+      addedInterfaceName: iface.name,
+    },
   };
+}
+
+function buildObjectTypeInterfaceRemovedMessage(args: ObjectTypeInterfaceRemoved) {
+  return `'${args.meta.objectTypeName}' object type no longer implements '${args.meta.removedInterfaceName}' interface`;
 }
 
 export function objectTypeInterfaceRemoved(
   iface: GraphQLInterfaceType,
   type: GraphQLObjectType,
-): Change {
+): Change<ChangeType.ObjectTypeInterfaceRemoved> {
   return {
     criticality: {
       level: CriticalityLevel.Breaking,
@@ -28,7 +48,13 @@ export function objectTypeInterfaceRemoved(
         'Removing an interface from an object type can cause existing queries that use this in a fragment spread to error.',
     },
     type: ChangeType.ObjectTypeInterfaceRemoved,
-    message: `'${type.name}' object type no longer implements '${iface.name}' interface`,
+    get message() {
+      return buildObjectTypeInterfaceRemovedMessage(this);
+    },
     path: type.name,
+    meta: {
+      objectTypeName: type.name,
+      removedInterfaceName: iface.name,
+    },
   };
 }

--- a/packages/core/src/diff/changes/object.ts
+++ b/packages/core/src/diff/changes/object.ts
@@ -7,54 +7,64 @@ import {
   ObjectTypeInterfaceRemoved,
 } from './change';
 
-function buildObjectTypeInterfaceAddedMessage(args: ObjectTypeInterfaceAdded) {
-  return `'${args.meta.objectTypeName}' object implements '${args.meta.addedInterfaceName}' interface`;
+function buildObjectTypeInterfaceAddedMessage(args: ObjectTypeInterfaceAdded['meta']) {
+  return `'${args.objectTypeName}' object implements '${args.addedInterfaceName}' interface`;
+}
+
+export function objectTypeInterfaceAddedFromMeta(args: ObjectTypeInterfaceAdded) {
+  return {
+    type: ChangeType.ObjectTypeInterfaceAdded,
+    criticality: {
+      level: CriticalityLevel.Dangerous,
+      reason:
+        'Adding an interface to an object type may break existing clients that were not programming defensively against a new possible type.',
+    },
+    message: buildObjectTypeInterfaceAddedMessage(args.meta),
+    meta: args.meta,
+    path: args.meta.objectTypeName,
+  } as const;
 }
 
 export function objectTypeInterfaceAdded(
   iface: GraphQLInterfaceType,
   type: GraphQLObjectType,
 ): Change<ChangeType.ObjectTypeInterfaceAdded> {
-  return {
-    criticality: {
-      level: CriticalityLevel.Dangerous,
-      reason:
-        'Adding an interface to an object type may break existing clients that were not programming defensively against a new possible type.',
-    },
+  return objectTypeInterfaceAddedFromMeta({
     type: ChangeType.ObjectTypeInterfaceAdded,
-    get message() {
-      return buildObjectTypeInterfaceAddedMessage(this);
-    },
-    path: type.name,
     meta: {
       objectTypeName: type.name,
       addedInterfaceName: iface.name,
     },
-  };
+  });
 }
 
-function buildObjectTypeInterfaceRemovedMessage(args: ObjectTypeInterfaceRemoved) {
-  return `'${args.meta.objectTypeName}' object type no longer implements '${args.meta.removedInterfaceName}' interface`;
+function buildObjectTypeInterfaceRemovedMessage(args: ObjectTypeInterfaceRemoved['meta']) {
+  return `'${args.objectTypeName}' object type no longer implements '${args.removedInterfaceName}' interface`;
+}
+
+export function objectTypeInterfaceRemovedFromMeta(args: ObjectTypeInterfaceRemoved) {
+  return {
+    type: ChangeType.ObjectTypeInterfaceRemoved,
+    criticality: {
+      level: CriticalityLevel.Breaking,
+      reason:
+        'Removing an interface from an object type can cause existing queries that use this in a fragment spread to error.',
+    },
+    message: buildObjectTypeInterfaceRemovedMessage(args.meta),
+    meta: args.meta,
+    path: args.meta.objectTypeName,
+  } as const;
 }
 
 export function objectTypeInterfaceRemoved(
   iface: GraphQLInterfaceType,
   type: GraphQLObjectType,
 ): Change<ChangeType.ObjectTypeInterfaceRemoved> {
-  return {
-    criticality: {
-      level: CriticalityLevel.Breaking,
-      reason:
-        'Removing an interface from an object type can cause existing queries that use this in a fragment spread to error.',
-    },
+  return objectTypeInterfaceRemovedFromMeta({
     type: ChangeType.ObjectTypeInterfaceRemoved,
-    get message() {
-      return buildObjectTypeInterfaceRemovedMessage(this);
-    },
-    path: type.name,
     meta: {
       objectTypeName: type.name,
       removedInterfaceName: iface.name,
     },
-  };
+  });
 }

--- a/packages/core/src/diff/changes/schema.ts
+++ b/packages/core/src/diff/changes/schema.ts
@@ -8,8 +8,19 @@ import {
   SchemaSubscriptionTypeChanged,
 } from './change';
 
-function buildSchemaQueryTypeChangedMessage(args: SchemaQueryTypeChanged): string {
-  return `Schema query root has changed from '${args.meta.oldQueryTypeName}' to '${args.meta.newQueryTypeName}'`;
+function buildSchemaQueryTypeChangedMessage(args: SchemaQueryTypeChanged['meta']): string {
+  return `Schema query root has changed from '${args.oldQueryTypeName}' to '${args.newQueryTypeName}'`;
+}
+
+export function schemaQueryTypeChangedFromMeta(args: SchemaQueryTypeChanged) {
+  return {
+    type: ChangeType.SchemaQueryTypeChanged,
+    criticality: {
+      level: CriticalityLevel.Breaking,
+    },
+    message: buildSchemaQueryTypeChangedMessage(args.meta),
+    meta: args.meta,
+  } as const;
 }
 
 export function schemaQueryTypeChanged(
@@ -19,23 +30,28 @@ export function schemaQueryTypeChanged(
   const oldName = (oldSchema.getQueryType() || ({} as any)).name || 'unknown';
   const newName = (newSchema.getQueryType() || ({} as any)).name || 'unknown';
 
-  return {
-    criticality: {
-      level: CriticalityLevel.Breaking,
-    },
+  return schemaQueryTypeChangedFromMeta({
     type: ChangeType.SchemaQueryTypeChanged,
-    get message() {
-      return buildSchemaQueryTypeChangedMessage(this);
-    },
     meta: {
       oldQueryTypeName: oldName,
       newQueryTypeName: newName,
     },
-  };
+  });
 }
 
-function buildSchemaMutationTypeChangedMessage(args: SchemaMutationTypeChanged): string {
-  return `Schema mutation root has changed from '${args.meta.oldMutationTypeName}' to '${args.meta.newMutationTypeName}'`;
+function buildSchemaMutationTypeChangedMessage(args: SchemaMutationTypeChanged['meta']): string {
+  return `Schema mutation root has changed from '${args.oldMutationTypeName}' to '${args.newMutationTypeName}'`;
+}
+
+export function schemaMutationTypeChangedFromMeta(args: SchemaMutationTypeChanged) {
+  return {
+    type: ChangeType.SchemaMutationTypeChanged,
+    criticality: {
+      level: CriticalityLevel.Breaking,
+    },
+    message: buildSchemaMutationTypeChangedMessage(args.meta),
+    meta: args.meta,
+  } as const;
 }
 
 export function schemaMutationTypeChanged(
@@ -45,23 +61,30 @@ export function schemaMutationTypeChanged(
   const oldName = (oldSchema.getMutationType() || ({} as any)).name || 'unknown';
   const newName = (newSchema.getMutationType() || ({} as any)).name || 'unknown';
 
-  return {
-    criticality: {
-      level: CriticalityLevel.Breaking,
-    },
+  return schemaMutationTypeChangedFromMeta({
     type: ChangeType.SchemaMutationTypeChanged,
-    get message() {
-      return buildSchemaMutationTypeChangedMessage(this);
-    },
     meta: {
       newMutationTypeName: newName,
       oldMutationTypeName: oldName,
     },
-  };
+  });
 }
 
-function buildSchemaSubscriptionTypeChangedMessage(args: SchemaSubscriptionTypeChanged): string {
-  return `Schema subscription root has changed from '${args.meta.oldSubscriptionTypeName}' to '${args.meta.newSubscriptionTypeName}'`;
+function buildSchemaSubscriptionTypeChangedMessage(
+  args: SchemaSubscriptionTypeChanged['meta'],
+): string {
+  return `Schema subscription root has changed from '${args.oldSubscriptionTypeName}' to '${args.newSubscriptionTypeName}'`;
+}
+
+export function schemaSubscriptionTypeChangedFromMeta(args: SchemaSubscriptionTypeChanged) {
+  return {
+    type: ChangeType.SchemaSubscriptionTypeChanged,
+    criticality: {
+      level: CriticalityLevel.Breaking,
+    },
+    message: buildSchemaSubscriptionTypeChangedMessage(args.meta),
+    meta: args.meta,
+  } as const;
 }
 
 export function schemaSubscriptionTypeChanged(
@@ -71,17 +94,11 @@ export function schemaSubscriptionTypeChanged(
   const oldName = (oldSchema.getSubscriptionType() || ({} as any)).name || 'unknown';
   const newName = (newSchema.getSubscriptionType() || ({} as any)).name || 'unknown';
 
-  return {
-    criticality: {
-      level: CriticalityLevel.Breaking,
-    },
+  return schemaSubscriptionTypeChangedFromMeta({
     type: ChangeType.SchemaSubscriptionTypeChanged,
-    get message() {
-      return buildSchemaSubscriptionTypeChangedMessage(this);
-    },
     meta: {
       newSubscriptionTypeName: newName,
       oldSubscriptionTypeName: oldName,
     },
-  };
+  });
 }

--- a/packages/core/src/diff/changes/schema.ts
+++ b/packages/core/src/diff/changes/schema.ts
@@ -1,7 +1,21 @@
 import { GraphQLSchema } from 'graphql';
-import { Change, ChangeType, CriticalityLevel } from './change';
+import {
+  Change,
+  ChangeType,
+  CriticalityLevel,
+  SchemaMutationTypeChanged,
+  SchemaQueryTypeChanged,
+  SchemaSubscriptionTypeChanged,
+} from './change';
 
-export function schemaQueryTypeChanged(oldSchema: GraphQLSchema, newSchema: GraphQLSchema): Change {
+function buildSchemaQueryTypeChangedMessage(args: SchemaQueryTypeChanged): string {
+  return `Schema query root has changed from '${args.meta.oldQueryTypeName}' to '${args.meta.newQueryTypeName}'`;
+}
+
+export function schemaQueryTypeChanged(
+  oldSchema: GraphQLSchema,
+  newSchema: GraphQLSchema,
+): Change<ChangeType.SchemaQueryTypeChanged> {
   const oldName = (oldSchema.getQueryType() || ({} as any)).name || 'unknown';
   const newName = (newSchema.getQueryType() || ({} as any)).name || 'unknown';
 
@@ -10,13 +24,24 @@ export function schemaQueryTypeChanged(oldSchema: GraphQLSchema, newSchema: Grap
       level: CriticalityLevel.Breaking,
     },
     type: ChangeType.SchemaQueryTypeChanged,
-    message: `Schema query root has changed from '${oldName}' to '${newName}'`,
+    get message() {
+      return buildSchemaQueryTypeChangedMessage(this);
+    },
+    meta: {
+      oldQueryTypeName: oldName,
+      newQueryTypeName: newName,
+    },
   };
 }
+
+function buildSchemaMutationTypeChangedMessage(args: SchemaMutationTypeChanged): string {
+  return `Schema mutation root has changed from '${args.meta.oldMutationTypeName}' to '${args.meta.newMutationTypeName}'`;
+}
+
 export function schemaMutationTypeChanged(
   oldSchema: GraphQLSchema,
   newSchema: GraphQLSchema,
-): Change {
+): Change<ChangeType.SchemaMutationTypeChanged> {
   const oldName = (oldSchema.getMutationType() || ({} as any)).name || 'unknown';
   const newName = (newSchema.getMutationType() || ({} as any)).name || 'unknown';
 
@@ -25,13 +50,24 @@ export function schemaMutationTypeChanged(
       level: CriticalityLevel.Breaking,
     },
     type: ChangeType.SchemaMutationTypeChanged,
-    message: `Schema mutation root has changed from '${oldName}' to '${newName}'`,
+    get message() {
+      return buildSchemaMutationTypeChangedMessage(this);
+    },
+    meta: {
+      newMutationTypeName: newName,
+      oldMutationTypeName: oldName,
+    },
   };
 }
+
+function buildSchemaSubscriptionTypeChangedMessage(args: SchemaSubscriptionTypeChanged): string {
+  return `Schema subscription root has changed from '${args.meta.oldSubscriptionTypeName}' to '${args.meta.newSubscriptionTypeName}'`;
+}
+
 export function schemaSubscriptionTypeChanged(
   oldSchema: GraphQLSchema,
   newSchema: GraphQLSchema,
-): Change {
+): Change<ChangeType.SchemaSubscriptionTypeChanged> {
   const oldName = (oldSchema.getSubscriptionType() || ({} as any)).name || 'unknown';
   const newName = (newSchema.getSubscriptionType() || ({} as any)).name || 'unknown';
 
@@ -40,6 +76,12 @@ export function schemaSubscriptionTypeChanged(
       level: CriticalityLevel.Breaking,
     },
     type: ChangeType.SchemaSubscriptionTypeChanged,
-    message: `Schema subscription root has changed from '${oldName}' to '${newName}'`,
+    get message() {
+      return buildSchemaSubscriptionTypeChangedMessage(this);
+    },
+    meta: {
+      newSubscriptionTypeName: newName,
+      oldSubscriptionTypeName: oldName,
+    },
   };
 }

--- a/packages/core/src/diff/changes/type.ts
+++ b/packages/core/src/diff/changes/type.ts
@@ -12,139 +12,169 @@ import {
   TypeRemoved,
 } from './change';
 
-function buildTypeRemovedMessage(type: TypeRemoved): string {
-  return `Type '${type.meta.removedTypeName}' was removed`;
+function buildTypeRemovedMessage(type: TypeRemoved['meta']): string {
+  return `Type '${type.removedTypeName}' was removed`;
 }
 
-export function typeRemoved(type: GraphQLNamedType): Change<ChangeType.TypeRemoved> {
+export function typeRemovedFromMeta(args: TypeRemoved) {
   return {
     criticality: {
       level: CriticalityLevel.Breaking,
     },
     type: ChangeType.TypeRemoved,
-    get message() {
-      return buildTypeRemovedMessage(this);
-    },
-    path: type.name,
+    message: buildTypeRemovedMessage(args.meta),
+    meta: args.meta,
+    path: args.meta.removedTypeName,
+  } as const;
+}
+
+export function typeRemoved(type: GraphQLNamedType): Change<ChangeType.TypeRemoved> {
+  return typeRemovedFromMeta({
+    type: ChangeType.TypeRemoved,
     meta: {
       removedTypeName: type.name,
     },
-  };
+  });
 }
 
-function buildTypeAddedMessage(type: TypeAdded): string {
-  return `Type '${type.meta.addedTypeName}' was added`;
+function buildTypeAddedMessage(type: TypeAdded['meta']): string {
+  return `Type '${type.addedTypeName}' was added`;
 }
 
-export function typeAdded(type: GraphQLNamedType): Change<ChangeType.TypeAdded> {
+export function typeAddedFromMeta(args: TypeAdded) {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.TypeAdded,
-    get message() {
-      return buildTypeAddedMessage(this);
-    },
-    path: type.name,
+    message: buildTypeAddedMessage(args.meta),
+    meta: args.meta,
+    path: args.meta.addedTypeName,
+  } as const;
+}
+
+export function typeAdded(type: GraphQLNamedType): Change<ChangeType.TypeAdded> {
+  return typeAddedFromMeta({
+    type: ChangeType.TypeAdded,
     meta: {
       addedTypeName: type.name,
     },
-  };
+  });
 }
 
 function buildTypeKindChangedMessage(args: TypeKindChanged): string {
   return `'${args.meta.typeName}' kind changed from '${args.meta.oldTypeKind}' to '${args.meta.newTypeKind}'`;
 }
 
-export function typeKindChanged(
-  oldType: GraphQLNamedType,
-  newType: GraphQLNamedType,
-): Change<ChangeType.TypeKindChanged> {
+export function typeKindChangedFromMeta(args: TypeKindChanged) {
   return {
     criticality: {
       level: CriticalityLevel.Breaking,
       reason: `Changing the kind of a type is a breaking change because it can cause existing queries to error. For example, turning an object type to a scalar type would break queries that define a selection set for this type.`,
     },
     type: ChangeType.TypeKindChanged,
-    get message() {
-      return buildTypeKindChangedMessage(this);
-    },
-    path: oldType.name,
+    message: buildTypeKindChangedMessage(args),
+    path: args.meta.typeName,
+    meta: args.meta,
+  } as const;
+}
+
+export function typeKindChanged(
+  oldType: GraphQLNamedType,
+  newType: GraphQLNamedType,
+): Change<ChangeType.TypeKindChanged> {
+  return typeKindChangedFromMeta({
+    type: ChangeType.TypeKindChanged,
     meta: {
       typeName: oldType.name,
       newTypeKind: String(getKind(newType)),
       oldTypeKind: String(getKind(oldType)),
     },
-  };
+  });
 }
 
-function buildTypeDescriptionChangedMessage(args: TypeDescriptionChanged): string {
-  return `Description '${args.meta.oldTypeDescription}' on type '${args.meta.typeName}' has changed to '${args.meta.newTypeDescription}'`;
+function buildTypeDescriptionChangedMessage(args: TypeDescriptionChanged['meta']): string {
+  return `Description '${args.oldTypeDescription}' on type '${args.typeName}' has changed to '${args.newTypeDescription}'`;
+}
+
+export function typeDescriptionChangedFromMeta(args: TypeDescriptionChanged) {
+  return {
+    criticality: {
+      level: CriticalityLevel.NonBreaking,
+    },
+    type: ChangeType.TypeDescriptionChanged,
+    message: buildTypeDescriptionChangedMessage(args.meta),
+    path: args.meta.typeName,
+    meta: args.meta,
+  } as const;
 }
 
 export function typeDescriptionChanged(
   oldType: GraphQLNamedType,
   newType: GraphQLNamedType,
 ): Change<ChangeType.TypeDescriptionChanged> {
-  return {
-    criticality: {
-      level: CriticalityLevel.NonBreaking,
-    },
+  return typeDescriptionChangedFromMeta({
     type: ChangeType.TypeDescriptionChanged,
-    get message() {
-      return buildTypeDescriptionChangedMessage(this);
-    },
-    path: oldType.name,
     meta: {
       typeName: oldType.name,
       newTypeDescription: newType.description ?? '',
       oldTypeDescription: oldType.description ?? '',
     },
-  };
+  });
 }
 
-function buildTypeDescriptionRemoved(args: TypeDescriptionRemoved): string {
-  return `Description '${args.meta.removedTypeDescription}' was removed from object type '${args.meta.typeName}'`;
+function buildTypeDescriptionRemoved(args: TypeDescriptionRemoved['meta']): string {
+  return `Description '${args.removedTypeDescription}' was removed from object type '${args.typeName}'`;
 }
 
-export function typeDescriptionRemoved(
-  type: GraphQLNamedType,
-): Change<ChangeType.TypeDescriptionRemoved> {
+export function typeDescriptionRemovedFromMeta(args: TypeDescriptionRemoved) {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.TypeDescriptionRemoved,
-    get message() {
-      return buildTypeDescriptionRemoved(this);
-    },
-    path: type.name,
+    message: buildTypeDescriptionRemoved(args.meta),
+    path: args.meta.typeName,
+    meta: args.meta,
+  } as const;
+}
+
+export function typeDescriptionRemoved(
+  type: GraphQLNamedType,
+): Change<ChangeType.TypeDescriptionRemoved> {
+  return typeDescriptionRemovedFromMeta({
+    type: ChangeType.TypeDescriptionRemoved,
     meta: {
       typeName: type.name,
       removedTypeDescription: type.description ?? '',
     },
-  };
+  });
 }
 
-function buildTypeDescriptionAddedMessage(args: TypeDescriptionAdded): string {
-  return `Object type '${args.meta.typeName}' has description '${args.meta.addedTypeDescription}'`;
+function buildTypeDescriptionAddedMessage(args: TypeDescriptionAdded['meta']): string {
+  return `Object type '${args.typeName}' has description '${args.addedTypeDescription}'`;
 }
 
-export function typeDescriptionAdded(
-  type: GraphQLNamedType,
-): Change<ChangeType.TypeDescriptionAdded> {
+export function typeDescriptionAddedFromMeta(args: TypeDescriptionAdded) {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.TypeDescriptionAdded,
-    get message() {
-      return buildTypeDescriptionAddedMessage(this);
-    },
-    path: type.name,
+    message: buildTypeDescriptionAddedMessage(args.meta),
+    path: args.meta.typeName,
+    meta: args.meta,
+  } as const;
+}
+
+export function typeDescriptionAdded(
+  type: GraphQLNamedType,
+): Change<ChangeType.TypeDescriptionAdded> {
+  return typeDescriptionAddedFromMeta({
+    type: ChangeType.TypeDescriptionAdded,
     meta: {
       typeName: type.name,
       addedTypeDescription: type.description ?? '',
     },
-  };
+  });
 }

--- a/packages/core/src/diff/changes/type.ts
+++ b/packages/core/src/diff/changes/type.ts
@@ -1,70 +1,150 @@
 import { GraphQLNamedType } from 'graphql';
 import { getKind } from '../../utils/graphql';
-import { Change, ChangeType, CriticalityLevel } from './change';
+import {
+  Change,
+  ChangeType,
+  CriticalityLevel,
+  TypeAdded,
+  TypeDescriptionAdded,
+  TypeDescriptionChanged,
+  TypeDescriptionRemoved,
+  TypeKindChanged,
+  TypeRemoved,
+} from './change';
 
-export function typeRemoved(type: GraphQLNamedType): Change {
+function buildTypeRemovedMessage(type: TypeRemoved): string {
+  return `Type '${type.meta.removedTypeName}' was removed`;
+}
+
+export function typeRemoved(type: GraphQLNamedType): Change<ChangeType.TypeRemoved> {
   return {
     criticality: {
       level: CriticalityLevel.Breaking,
     },
     type: ChangeType.TypeRemoved,
-    message: `Type '${type.name}' was removed`,
+    get message() {
+      return buildTypeRemovedMessage(this);
+    },
     path: type.name,
+    meta: {
+      removedTypeName: type.name,
+    },
   };
 }
-export function typeAdded(type: GraphQLNamedType): Change {
+
+function buildTypeAddedMessage(type: TypeAdded): string {
+  return `Type '${type.meta.addedTypeName}' was added`;
+}
+
+export function typeAdded(type: GraphQLNamedType): Change<ChangeType.TypeAdded> {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.TypeAdded,
-    message: `Type '${type.name}' was added`,
+    get message() {
+      return buildTypeAddedMessage(this);
+    },
     path: type.name,
+    meta: {
+      addedTypeName: type.name,
+    },
   };
 }
-export function typeKindChanged(oldType: GraphQLNamedType, newType: GraphQLNamedType): Change {
+
+function buildTypeKindChangedMessage(args: TypeKindChanged): string {
+  return `'${args.meta.typeName}' kind changed from '${args.meta.oldTypeKind}' to '${args.meta.newTypeKind}'`;
+}
+
+export function typeKindChanged(
+  oldType: GraphQLNamedType,
+  newType: GraphQLNamedType,
+): Change<ChangeType.TypeKindChanged> {
   return {
     criticality: {
       level: CriticalityLevel.Breaking,
       reason: `Changing the kind of a type is a breaking change because it can cause existing queries to error. For example, turning an object type to a scalar type would break queries that define a selection set for this type.`,
     },
     type: ChangeType.TypeKindChanged,
-    message: `'${oldType.name}' kind changed from '${getKind(oldType)}' to '${getKind(newType)}'`,
+    get message() {
+      return buildTypeKindChangedMessage(this);
+    },
     path: oldType.name,
+    meta: {
+      typeName: oldType.name,
+      newTypeKind: String(getKind(newType)),
+      oldTypeKind: String(getKind(oldType)),
+    },
   };
 }
+
+function buildTypeDescriptionChangedMessage(args: TypeDescriptionChanged): string {
+  return `Description '${args.meta.oldTypeDescription}' on type '${args.meta.typeName}' has changed to '${args.meta.newTypeDescription}'`;
+}
+
 export function typeDescriptionChanged(
   oldType: GraphQLNamedType,
   newType: GraphQLNamedType,
-): Change {
+): Change<ChangeType.TypeDescriptionChanged> {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.TypeDescriptionChanged,
-    message: `Description '${oldType.description}' on type '${oldType.name}' has changed to '${newType.description}'`,
+    get message() {
+      return buildTypeDescriptionChangedMessage(this);
+    },
     path: oldType.name,
+    meta: {
+      typeName: oldType.name,
+      newTypeDescription: newType.description ?? '',
+      oldTypeDescription: oldType.description ?? '',
+    },
   };
 }
 
-export function typeDescriptionRemoved(type: GraphQLNamedType): Change {
+function buildTypeDescriptionRemoved(args: TypeDescriptionRemoved): string {
+  return `Description '${args.meta.removedTypeDescription}' was removed from object type '${args.meta.typeName}'`;
+}
+
+export function typeDescriptionRemoved(
+  type: GraphQLNamedType,
+): Change<ChangeType.TypeDescriptionRemoved> {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.TypeDescriptionRemoved,
-    message: `Description '${type.description}' was removed from object type '${type.name}'`,
+    get message() {
+      return buildTypeDescriptionRemoved(this);
+    },
     path: type.name,
+    meta: {
+      typeName: type.name,
+      removedTypeDescription: type.description ?? '',
+    },
   };
 }
 
-export function typeDescriptionAdded(type: GraphQLNamedType): Change {
+function buildTypeDescriptionAddedMessage(args: TypeDescriptionAdded): string {
+  return `Object type '${args.meta.typeName}' has description '${args.meta.addedTypeDescription}'`;
+}
+
+export function typeDescriptionAdded(
+  type: GraphQLNamedType,
+): Change<ChangeType.TypeDescriptionAdded> {
   return {
     criticality: {
       level: CriticalityLevel.NonBreaking,
     },
     type: ChangeType.TypeDescriptionAdded,
-    message: `Object type '${type.name}' has description '${type.description}'`,
+    get message() {
+      return buildTypeDescriptionAddedMessage(this);
+    },
     path: type.name,
+    meta: {
+      typeName: type.name,
+      addedTypeDescription: type.description ?? '',
+    },
   };
 }

--- a/packages/core/src/diff/changes/union.ts
+++ b/packages/core/src/diff/changes/union.ts
@@ -1,7 +1,20 @@
 import { GraphQLObjectType, GraphQLUnionType } from 'graphql';
-import { Change, ChangeType, CriticalityLevel } from './change';
+import {
+  Change,
+  ChangeType,
+  CriticalityLevel,
+  UnionMemberAdded,
+  UnionMemberRemoved,
+} from './change';
 
-export function unionMemberRemoved(union: GraphQLUnionType, type: GraphQLObjectType): Change {
+function buildUnionMemberRemovedMessage(args: UnionMemberRemoved) {
+  return `Member '${args.meta.removedUnionMemberTypeName}' was removed from Union type '${args.meta.unionName}'`;
+}
+
+export function unionMemberRemoved(
+  union: GraphQLUnionType,
+  type: GraphQLObjectType,
+): Change<ChangeType.UnionMemberRemoved> {
   return {
     criticality: {
       level: CriticalityLevel.Breaking,
@@ -9,12 +22,25 @@ export function unionMemberRemoved(union: GraphQLUnionType, type: GraphQLObjectT
         'Removing a union member from a union can cause existing queries that use this union member in a fragment spread to error.',
     },
     type: ChangeType.UnionMemberRemoved,
-    message: `Member '${type.name}' was removed from Union type '${union.name}'`,
+    get message() {
+      return buildUnionMemberRemovedMessage(this);
+    },
     path: union.name,
+    meta: {
+      unionName: union.name,
+      removedUnionMemberTypeName: type.name,
+    },
   };
 }
 
-export function unionMemberAdded(union: GraphQLUnionType, type: GraphQLObjectType): Change {
+function buildUnionMemberAddedMessage(args: UnionMemberAdded) {
+  return `Member '${args.meta.addedUnionMemberTypeName}' was added to Union type '${args.meta.unionName}'`;
+}
+
+export function unionMemberAdded(
+  union: GraphQLUnionType,
+  type: GraphQLObjectType,
+): Change<ChangeType.UnionMemberAdded> {
   return {
     criticality: {
       level: CriticalityLevel.Dangerous,
@@ -22,7 +48,13 @@ export function unionMemberAdded(union: GraphQLUnionType, type: GraphQLObjectTyp
         'Adding a possible type to Unions may break existing clients that were not programming defensively against a new possible type.',
     },
     type: ChangeType.UnionMemberAdded,
-    message: `Member '${type.name}' was added to Union type '${union.name}'`,
+    get message() {
+      return buildUnionMemberAddedMessage(this);
+    },
     path: union.name,
+    meta: {
+      unionName: union.name,
+      addedUnionMemberTypeName: type.name,
+    },
   };
 }

--- a/packages/core/src/diff/changes/union.ts
+++ b/packages/core/src/diff/changes/union.ts
@@ -7,14 +7,11 @@ import {
   UnionMemberRemoved,
 } from './change';
 
-function buildUnionMemberRemovedMessage(args: UnionMemberRemoved) {
-  return `Member '${args.meta.removedUnionMemberTypeName}' was removed from Union type '${args.meta.unionName}'`;
+function buildUnionMemberRemovedMessage(args: UnionMemberRemoved['meta']) {
+  return `Member '${args.removedUnionMemberTypeName}' was removed from Union type '${args.unionName}'`;
 }
 
-export function unionMemberRemoved(
-  union: GraphQLUnionType,
-  type: GraphQLObjectType,
-): Change<ChangeType.UnionMemberRemoved> {
+export function unionMemberRemovedFromMeta(args: UnionMemberRemoved) {
   return {
     criticality: {
       level: CriticalityLevel.Breaking,
@@ -22,25 +19,30 @@ export function unionMemberRemoved(
         'Removing a union member from a union can cause existing queries that use this union member in a fragment spread to error.',
     },
     type: ChangeType.UnionMemberRemoved,
-    get message() {
-      return buildUnionMemberRemovedMessage(this);
-    },
-    path: union.name,
+    message: buildUnionMemberRemovedMessage(args.meta),
+    meta: args.meta,
+    path: args.meta.unionName,
+  } as const;
+}
+
+export function unionMemberRemoved(
+  union: GraphQLUnionType,
+  type: GraphQLObjectType,
+): Change<ChangeType.UnionMemberRemoved> {
+  return unionMemberRemovedFromMeta({
+    type: ChangeType.UnionMemberRemoved,
     meta: {
       unionName: union.name,
       removedUnionMemberTypeName: type.name,
     },
-  };
+  });
 }
 
-function buildUnionMemberAddedMessage(args: UnionMemberAdded) {
-  return `Member '${args.meta.addedUnionMemberTypeName}' was added to Union type '${args.meta.unionName}'`;
+function buildUnionMemberAddedMessage(args: UnionMemberAdded['meta']) {
+  return `Member '${args.addedUnionMemberTypeName}' was added to Union type '${args.unionName}'`;
 }
 
-export function unionMemberAdded(
-  union: GraphQLUnionType,
-  type: GraphQLObjectType,
-): Change<ChangeType.UnionMemberAdded> {
+export function buildUnionMemberAddedMessageFromMeta(args: UnionMemberAdded) {
   return {
     criticality: {
       level: CriticalityLevel.Dangerous,
@@ -48,13 +50,21 @@ export function unionMemberAdded(
         'Adding a possible type to Unions may break existing clients that were not programming defensively against a new possible type.',
     },
     type: ChangeType.UnionMemberAdded,
-    get message() {
-      return buildUnionMemberAddedMessage(this);
-    },
-    path: union.name,
+    message: buildUnionMemberAddedMessage(args.meta),
+    meta: args.meta,
+    path: args.meta.unionName,
+  } as const;
+}
+
+export function unionMemberAdded(
+  union: GraphQLUnionType,
+  type: GraphQLObjectType,
+): Change<ChangeType.UnionMemberAdded> {
+  return buildUnionMemberAddedMessageFromMeta({
+    type: ChangeType.UnionMemberAdded,
     meta: {
       unionName: union.name,
       addedUnionMemberTypeName: type.name,
     },
-  };
+  });
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,3 +13,74 @@ export {
 export { countDirectives } from './validate/directive-count';
 export { countDepth } from './validate/query-depth';
 export { calculateTokenCount } from './validate/token-count';
+
+export {
+  fieldArgumentDescriptionFromMeta,
+  fieldArgumentDefaultChangedFromMeta,
+  fieldArgumentTypeChangedFromMeta,
+} from './diff/changes/argument';
+export {
+  directiveRemovedFromMeta,
+  directiveAddedFromMeta,
+  directiveDescriptionChangedFromMeta,
+  directiveLocationAddedFromMeta,
+  directiveLocationRemovedFromMeta,
+  directiveArgumentAddedFromMeta,
+  directiveArgumentRemovedFromMeta,
+  directiveArgumentDescriptionChangedFromMeta,
+  directiveArgumentDefaultValueChangedFromMeta,
+  directiveArgumentTypeChangedFromMeta,
+} from './diff/changes/directive';
+export {
+  enumValueRemovedFromMeta,
+  enumValueAddedFromMeta,
+  enumValueDescriptionChangedFromMeta,
+  enumValueDeprecationReasonChangedFromMeta,
+  enumValueDeprecationReasonAddedFromMeta,
+  enumValueDeprecationReasonRemovedFromMeta,
+} from './diff/changes/enum';
+export {
+  fieldRemovedFromMeta,
+  fieldAddedFromMeta,
+  fieldDescriptionChangedFromMeta,
+  fieldDescriptionAddedFromMeta,
+  fieldDescriptionRemovedFromMeta,
+  fieldDeprecationAddedFromMeta,
+  fieldDeprecationRemovedFromMeta,
+  fieldDeprecationReasonChangedFromMeta,
+  fieldDeprecationReasonAddedFromMeta,
+  fieldDeprecationReasonRemovedFromMeta,
+  fieldTypeChangedFromMeta,
+  fieldArgumentAddedFromMeta,
+  fieldArgumentRemovedFromMeta,
+} from './diff/changes/field';
+export {
+  inputFieldRemovedFromMeta,
+  inputFieldAddedFromMeta,
+  inputFieldDescriptionAddedFromMeta,
+  inputFieldDescriptionRemovedFromMeta,
+  inputFieldDescriptionChangedFromMeta,
+  inputFieldDefaultValueChangedFromMeta,
+  inputFieldTypeChangedFromMeta,
+} from './diff/changes/input';
+export {
+  objectTypeInterfaceAddedFromMeta,
+  objectTypeInterfaceRemovedFromMeta,
+} from './diff/changes/object';
+export {
+  schemaQueryTypeChangedFromMeta,
+  schemaMutationTypeChangedFromMeta,
+  schemaSubscriptionTypeChangedFromMeta,
+} from './diff/changes/schema';
+export {
+  typeRemovedFromMeta,
+  typeAddedFromMeta,
+  typeKindChangedFromMeta,
+  typeDescriptionChangedFromMeta,
+  typeDescriptionRemovedFromMeta,
+  typeDescriptionAddedFromMeta,
+} from './diff/changes/type';
+export {
+  unionMemberRemovedFromMeta,
+  buildUnionMemberAddedMessageFromMeta,
+} from './diff/changes/union';

--- a/packages/core/src/utils/is-deprecated.ts
+++ b/packages/core/src/utils/is-deprecated.ts
@@ -2,9 +2,9 @@ import { GraphQLEnumValue, GraphQLField, GraphQLInputField } from 'graphql';
 
 export function isDeprecated(
   fieldOrEnumValue: GraphQLField<any, any> | GraphQLEnumValue | GraphQLInputField,
-) {
+): boolean {
   if ('isDeprecated' in fieldOrEnumValue) {
-    return fieldOrEnumValue['isDeprecated'];
+    return !!fieldOrEnumValue['isDeprecated'];
   }
   if (fieldOrEnumValue.deprecationReason != null) {
     return true;

--- a/packages/github/__tests__/diff.ts
+++ b/packages/github/__tests__/diff.ts
@@ -162,7 +162,7 @@ test('should work with comments and descriptions', async () => {
 test('use interceptor to modify changes', async () => {
   const scope = nock('https://api.com')
     .post('/intercept')
-    .reply(async (_, body: DiffInterceptorPayload) => {
+    .reply((async (_: any, body: DiffInterceptorPayload) => {
       const response: DiffInterceptorResponse = {
         changes: body.changes.map(c => {
           c.criticality.level = 'NON_BREAKING' as any;
@@ -170,7 +170,7 @@ test('use interceptor to modify changes', async () => {
         }),
       };
       return [200, response];
-    });
+    }) as any);
   const action = await diff({
     path: 'schema.graphql',
     ...build(oldSchema, newSchema),
@@ -180,7 +180,7 @@ test('use interceptor to modify changes', async () => {
   expect(action.annotations).toHaveLength(7);
   expect(action.changes).toHaveLength(7);
   expect(
-    action.changes.every(change => change.criticality.level === CriticalityLevel.NonBreaking),
+    action.changes?.every(change => change.criticality.level === CriticalityLevel.NonBreaking),
   ).toBe(true);
   expect(action.conclusion).toBe(CheckConclusion.Success);
 
@@ -190,13 +190,13 @@ test('use interceptor to modify changes', async () => {
 test('use interceptor to modify check conclusion', async () => {
   const scope = nock('https://api.com')
     .post('/intercept')
-    .reply(async (_, body: DiffInterceptorPayload) => {
+    .reply((async (_: any, body: DiffInterceptorPayload) => {
       const response: DiffInterceptorResponse = {
         changes: body.changes,
         conclusion: 'neutral' as any,
       };
       return [200, response];
-    });
+    }) as any);
   const action = await diff({
     path: 'schema.graphql',
     ...build(oldSchema, newSchema),

--- a/packages/github/__tests__/utils.ts
+++ b/packages/github/__tests__/utils.ts
@@ -11,6 +11,12 @@ describe('Limit summary', () => {
           criticality: {
             level: CriticalityLevel.Breaking,
           },
+          meta: {
+            typeName: 'foo',
+            removedFieldName: 'bar',
+            isRemovedFieldDeprecated: false,
+            typeType: 'INPUT_OBJECT',
+          },
         },
         {
           type: ChangeType.FieldRemoved,
@@ -18,12 +24,22 @@ describe('Limit summary', () => {
           criticality: {
             level: CriticalityLevel.Breaking,
           },
+          meta: {
+            typeName: 'foo',
+            removedFieldName: 'bar',
+            isRemovedFieldDeprecated: false,
+            typeType: 'INPUT_OBJECT',
+          },
         },
         {
           type: ChangeType.FieldAdded,
           message: 'safe-3',
           criticality: {
             level: CriticalityLevel.NonBreaking,
+          },
+          meta: {
+            typeName: 'foo',
+            addedFieldName: 'bar',
           },
         },
       ],
@@ -45,12 +61,24 @@ describe('Limit summary', () => {
           criticality: {
             level: CriticalityLevel.Breaking,
           },
+          meta: {
+            typeName: 'foo',
+            removedFieldName: 'bar',
+            isRemovedFieldDeprecated: false,
+            typeType: 'INPUT_OBJECT',
+          },
         },
         {
           type: ChangeType.FieldRemoved,
           message: 'breaking-2',
           criticality: {
             level: CriticalityLevel.Breaking,
+          },
+          meta: {
+            typeName: 'foo',
+            removedFieldName: 'bar',
+            isRemovedFieldDeprecated: false,
+            typeType: 'INPUT_OBJECT',
           },
         },
         {
@@ -59,12 +87,22 @@ describe('Limit summary', () => {
           criticality: {
             level: CriticalityLevel.Breaking,
           },
+          meta: {
+            typeName: 'foo',
+            removedFieldName: 'bar',
+            isRemovedFieldDeprecated: false,
+            typeType: 'INPUT_OBJECT',
+          },
         },
         {
           type: ChangeType.FieldAdded,
           message: 'safe-4',
           criticality: {
             level: CriticalityLevel.NonBreaking,
+          },
+          meta: {
+            typeName: 'foo',
+            addedFieldName: 'bar',
           },
         },
       ],
@@ -87,12 +125,24 @@ describe('Limit summary', () => {
           criticality: {
             level: CriticalityLevel.Breaking,
           },
+          meta: {
+            typeName: 'foo',
+            removedFieldName: 'bar',
+            isRemovedFieldDeprecated: false,
+            typeType: 'INPUT_OBJECT',
+          },
         },
         {
           type: ChangeType.FieldRemoved,
           message: 'breaking-2',
           criticality: {
             level: CriticalityLevel.Breaking,
+          },
+          meta: {
+            typeName: 'foo',
+            removedFieldName: 'bar',
+            isRemovedFieldDeprecated: false,
+            typeType: 'INPUT_OBJECT',
           },
         },
         {
@@ -101,12 +151,22 @@ describe('Limit summary', () => {
           criticality: {
             level: CriticalityLevel.Breaking,
           },
+          meta: {
+            typeName: 'foo',
+            removedFieldName: 'bar',
+            isRemovedFieldDeprecated: false,
+            typeType: 'INPUT_OBJECT',
+          },
         },
         {
           type: ChangeType.FieldAdded,
           message: 'safe-4',
           criticality: {
             level: CriticalityLevel.NonBreaking,
+          },
+          meta: {
+            typeName: 'foo',
+            addedFieldName: 'bar',
           },
         },
       ],

--- a/packages/github/src/helpers/utils.ts
+++ b/packages/github/src/helpers/utils.ts
@@ -28,7 +28,7 @@ export function filterChangesByLevel(level: CriticalityLevel) {
   return (change: Change) => change.criticality.level === level;
 }
 
-export function createSummary(changes: Change[], summaryLimit: number, isLegacyConfig: boolean) {
+export function createSummary(changes: Change[], summaryLimit: number, isLegacyConfig = false) {
   const breakingChanges = changes.filter(filterChangesByLevel(CriticalityLevel.Breaking));
   const dangerousChanges = changes.filter(filterChangesByLevel(CriticalityLevel.Dangerous));
   const safeChanges = changes.filter(filterChangesByLevel(CriticalityLevel.NonBreaking));


### PR DESCRIPTION
## Description

As part of https://github.com/kamilkisiela/graphql-hive/issues/1536 we want to store the meta data from graphql-inspector within our database. For this, we need to export these values as we do not want to store all the data.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [ ] TODO: tests for all rules 🙈

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
