### PR TITLE
fix: rename `coverage.stats.numFiledsCovered` to `coverage.stats.numFieldsCovered`

### DIFF
--- a/.changeset/strong-months-confess.md
+++ b/.changeset/strong-months-confess.md
@@ -1,0 +1,5 @@
+---
+'@graphql-inspector/core': patch
+---
+
+Fix typo for numFiledsCovered to numFieldsCovered

--- a/packages/core/src/coverage/index.ts
+++ b/packages/core/src/coverage/index.ts
@@ -82,6 +82,7 @@ export function coverage(schema: GraphQLSchema, sources: Source[]): SchemaCovera
       numTypesCoveredFully: 0,
       numTypesCovered: 0,
       numFields: 0,
+      numFieldsCovered: 0,
       numFiledsCovered: 0,
       numQueries: 0,
       numMutations: 0,

--- a/packages/core/src/coverage/index.ts
+++ b/packages/core/src/coverage/index.ts
@@ -60,10 +60,11 @@ export interface SchemaCoverage {
     numTypesCoveredFully: number;
     numTypesCovered: number;
     numFields: number;
-    numFiledsCovered: number;
     numQueries: number;
     numMutations: number;
     numSubscriptions: number;
+    numFieldsCovered: number;
+    numFiledsCovered: number; // deprecate and remove in next major version
   };
 }
 
@@ -206,7 +207,8 @@ export function coverage(schema: GraphQLSchema, sources: Source[]): SchemaCovera
     if (me.fieldsCountCovered > 0) coverage.stats.numTypesCovered++;
     if (me.fieldsCount === me.fieldsCountCovered) coverage.stats.numTypesCoveredFully++;
     coverage.stats.numFields += me.fieldsCount;
-    coverage.stats.numFiledsCovered += me.fieldsCountCovered;
+    coverage.stats.numFieldsCovered += me.fieldsCountCovered;
+    coverage.stats.numFiledsCovered = coverage.stats.numFieldsCovered;
   }
   return coverage;
 }

--- a/packages/core/src/coverage/index.ts
+++ b/packages/core/src/coverage/index.ts
@@ -64,7 +64,7 @@ export interface SchemaCoverage {
     numMutations: number;
     numSubscriptions: number;
     numFieldsCovered: number;
-    numFiledsCovered: number; // deprecate and remove in next major version
+    numFiledsCovered: number; // @deprecated will be removed in next major version
   };
 }
 


### PR DESCRIPTION
## Description

Adds a new field before removing and deprecating the old one with a typo.

Addresses #2424

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

TBD


## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

I will work on documentation and tests if I get a greenlight in #2424.