### PR TITLE
`Diff` identify changes in schema directives

### DIFF
--- a/.changeset/funny-cougars-mate.md
+++ b/.changeset/funny-cougars-mate.md
@@ -1,0 +1,26 @@
+---
+'@graphql-inspector/introspect-command': patch
+'@graphql-inspector/commands': patch
+'@graphql-inspector/coverage-command': patch
+'@graphql-inspector/validate-command': patch
+'@graphql-inspector/similar-command': patch
+'@graphql-inspector/graphql-loader': patch
+'@graphql-inspector/loaders': patch
+'@graphql-inspector/audit-command': patch
+'@graphql-inspector/serve-command': patch
+'@graphql-inspector/github-loader': patch
+'@graphql-inspector/diff-command': patch
+'@graphql-inspector/docs-command': patch
+'@graphql-inspector/code-loader': patch
+'@graphql-inspector/json-loader': patch
+'@graphql-inspector/git-loader': patch
+'@graphql-inspector/url-loader': patch
+'@graphql-inspector/action': patch
+'@graphql-inspector/config': patch
+'@graphql-inspector/logger': patch
+'@graphql-inspector/core': patch
+'@graphql-inspector/cli': patch
+'@graphql-inspector/ci': patch
+---
+
+Patch update - dependencies

--- a/.changeset/kind-cherries-lay.md
+++ b/.changeset/kind-cherries-lay.md
@@ -1,0 +1,5 @@
+---
+'@graphql-inspector/core': minor
+---
+
+Diff identify changes in schema directives

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ jobs:
     with:
       releaseScript: release
       nodeVersion: 18
-      packageManager: pnpm
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
       npmToken: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prettier": "pnpm lint:prettier --write",
     "release": "pnpm build && pnpm changeset publish",
     "release:canary": "npm run release -- canary",
-    "test": "vitest ."
+    "test": "vitest"
   },
   "dependencies": {
     "@sentry/node": "7.74.1",

--- a/packages/core/__tests__/diff/directive-usage.test.ts
+++ b/packages/core/__tests__/diff/directive-usage.test.ts
@@ -1,0 +1,719 @@
+import { buildSchema } from 'graphql';
+import { CriticalityLevel, diff } from '../../src/index.js';
+import { findFirstChangeByPath } from '../../utils/testing.js';
+
+describe('directive-usage', () => {
+  describe('field-level directives', () => {
+    test('added directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on FIELD_DEFINITION
+
+        type Query {
+          a: String
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on FIELD_DEFINITION
+
+        type Query {
+          a: String @external
+        }
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Query.a.external');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_FIELD_DEFINITION_ADDED');
+      expect(change.message).toEqual("Directive 'external' was added to field 'Query.a'");
+    });
+
+    test('removed directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on FIELD_DEFINITION
+
+        type Query {
+          a: String @external
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on FIELD_DEFINITION
+
+        type Query {
+          a: String
+        }
+      `);
+
+      const change = findFirstChangeByPath(await diff(a, b), 'Query.a.external');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_FIELD_DEFINITION_REMOVED');
+      expect(change.message).toEqual("Directive 'external' was removed from field 'Query.a'");
+    });
+
+    test('added oneOf directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @oneOf on FIELD_DEFINITION
+
+        type Query {
+          a: String
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @oneOf on FIELD_DEFINITION
+
+        type Query {
+          a: String @oneOf
+        }
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Query.a.oneOf');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Breaking);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_FIELD_DEFINITION_ADDED');
+      expect(change.message).toEqual("Directive 'oneOf' was added to field 'Query.a'");
+    });
+
+    test('removed oneOf directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @oneOf on FIELD_DEFINITION
+
+        type Query {
+          a: String @oneOf
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @oneOf on FIELD_DEFINITION
+
+        type Query {
+          a: String
+        }
+      `);
+
+      const change = findFirstChangeByPath(await diff(a, b), 'Query.a.oneOf');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.NonBreaking);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_FIELD_DEFINITION_REMOVED');
+      expect(change.message).toEqual("Directive 'oneOf' was removed from field 'Query.a'");
+    });
+  });
+
+  describe('union-level directives', () => {
+    test('added directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on UNION
+
+        type A {
+          a: String!
+        }
+
+        type B {
+          b: String!
+        }
+
+        union Foo = A | B
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on UNION
+
+        type A {
+          a: String!
+        }
+
+        type B {
+          b: String!
+        }
+
+        union Foo @external = A | B
+      `);
+
+      const change = findFirstChangeByPath(await diff(a, b), 'Foo.external');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_UNION_MEMBER_ADDED');
+      expect(change.message).toEqual("Directive 'external' was added to union member 'Foo'");
+    });
+
+    test('remove directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on UNION
+
+        type A {
+          a: String!
+        }
+
+        type B {
+          b: String!
+        }
+
+        union Foo @external = A | B
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on UNION
+
+        type A {
+          a: String!
+        }
+
+        type B {
+          b: String!
+        }
+
+        union Foo = A | B
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Foo.external');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_UNION_MEMBER_REMOVED');
+      expect(change.message).toEqual("Directive 'external' was removed from union member 'Foo'");
+    });
+
+    test('added oneOf directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @oneOf on UNION
+
+        type A {
+          a: String!
+        }
+
+        type B {
+          b: String!
+        }
+
+        union Foo = A | B
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @oneOf on UNION
+
+        type A {
+          a: String!
+        }
+
+        type B {
+          b: String!
+        }
+
+        union Foo @oneOf = A | B
+      `);
+
+      const change = findFirstChangeByPath(await diff(a, b), 'Foo.oneOf');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Breaking);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_UNION_MEMBER_ADDED');
+      expect(change.message).toEqual("Directive 'oneOf' was added to union member 'Foo'");
+    });
+
+    test('removed oneOf directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @oneOf on UNION
+
+        type A {
+          a: String!
+        }
+
+        type B {
+          b: String!
+        }
+
+        union Foo @oneOf = A | B
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @oneOf on UNION
+
+        type A {
+          a: String!
+        }
+
+        type B {
+          b: String!
+        }
+
+        union Foo = A | B
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Foo.oneOf');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.NonBreaking);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_UNION_MEMBER_REMOVED');
+      expect(change.message).toEqual("Directive 'oneOf' was removed from union member 'Foo'");
+    });
+  });
+
+  describe('enum-level directives', () => {
+    test('added directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on ENUM
+        type Query {
+          fieldA: String
+        }
+
+        enum enumA {
+          A
+          B
+        }
+      `);
+
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on ENUM
+        type Query {
+          fieldA: String
+        }
+
+        enum enumA @external {
+          A
+          B
+        }
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'enumA.external');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.criticality.reason).toBeDefined();
+      expect(change.message).toEqual(`Directive 'external' was added to enum 'enumA'`);
+    });
+
+    test('removed directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on ENUM
+        type Query {
+          fieldA: String
+        }
+
+        enum enumA @external {
+          A
+          B
+        }
+      `);
+
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on ENUM
+        type Query {
+          fieldA: String
+        }
+
+        enum enumA {
+          A
+          B
+        }
+      `);
+
+      const change = findFirstChangeByPath(await diff(a, b), 'enumA.external');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_ENUM_REMOVED');
+      expect(change.message).toEqual("Directive 'external' was removed from enum 'enumA'");
+    });
+  });
+
+  describe('enum-value-level directives', () => {
+    test('added directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on ENUM_VALUE
+        type Query {
+          fieldA: String
+        }
+
+        enum enumA {
+          A
+          B
+        }
+      `);
+
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on ENUM_VALUE
+
+        type Query {
+          fieldA: String
+        }
+
+        enum enumA {
+          A
+          B @external
+        }
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'enumA.B.external');
+
+      expect(changes.length).toEqual(1);
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.criticality.reason).toBeDefined();
+      expect(change.message).toEqual(`Directive 'external' was added to enum value 'enumA.B'`);
+    });
+
+    test('removed directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on ENUM_VALUE
+        type Query {
+          fieldA: String
+        }
+
+        enum enumA {
+          A
+          B
+        }
+      `);
+
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on ENUM_VALUE
+
+        type Query {
+          fieldA: String
+        }
+
+        enum enumA {
+          A @external
+          B
+        }
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'enumA.A.external');
+
+      expect(changes.length).toEqual(1);
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.criticality.reason).toBeDefined();
+      expect(change.message).toEqual(`Directive 'external' was added to enum value 'enumA.A'`);
+    });
+  });
+
+  describe('input-object-level directives', () => {
+    test('removed directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on INPUT_OBJECT
+        input Foo @external {
+          a: String
+          b: String
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on INPUT_OBJECT
+        input Foo {
+          a: String
+          b: String
+        }
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Foo.external');
+
+      expect(changes.length).toEqual(1);
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_INPUT_OBJECT_REMOVED');
+      expect(change.message).toEqual("Directive 'external' was removed from input object 'Foo'");
+    });
+    test('added directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on INPUT_OBJECT
+        input Foo {
+          a: String
+          b: String
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on INPUT_OBJECT
+        input Foo @external {
+          a: String
+          b: String
+        }
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Foo.external');
+
+      expect(changes.length).toEqual(1);
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_INPUT_OBJECT_ADDED');
+      expect(change.message).toEqual("Directive 'external' was added to input object 'Foo'");
+    });
+  });
+
+  describe('input-field-level directives', () => {
+    test('added directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on INPUT_FIELD_DEFINITION
+        input Foo {
+          a: String
+          b: String
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on INPUT_FIELD_DEFINITION
+        input Foo {
+          a: String @external
+          b: String
+        }
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Foo.a.external');
+
+      expect(changes.length).toEqual(1);
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_ARGUMENT_DEFINITION_ADDED');
+      expect(change.message).toEqual("Directive 'external' was added to argument 'a'");
+    });
+    test('removed directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on INPUT_FIELD_DEFINITION
+        input Foo {
+          a: String @external
+          b: String
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on INPUT_FIELD_DEFINITION
+        input Foo {
+          a: String
+          b: String
+        }
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Foo.a.external');
+
+      expect(changes.length).toEqual(1);
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_ARGUMENT_DEFINITION_REMOVED');
+      expect(change.message).toEqual("Directive 'external' was removed from input value 'Foo.a'");
+    });
+  });
+
+  describe('scalar-level directives', () => {
+    test('added directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on SCALAR
+        scalar Foo
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on SCALAR
+        scalar Foo @external
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Foo.external');
+
+      expect(changes.length).toEqual(1);
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_SCALAR_ADDED');
+      expect(change.message).toEqual("Directive 'external' was added to scalar 'Foo'");
+    });
+    test('removed directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on SCALAR
+        scalar Foo @external
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on SCALAR
+        scalar Foo
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Foo.external');
+
+      expect(changes.length).toEqual(1);
+      expect(change.criticality.level).toEqual(CriticalityLevel.Breaking);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_SCALAR_REMOVED');
+      expect(change.message).toEqual("Directive 'external' was removed from scalar 'Foo'");
+    });
+  });
+
+  describe('object-level directives', () => {
+    test('added directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on OBJECT
+        type Foo {
+          a: String
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on OBJECT
+        type Foo @external {
+          a: String
+        }
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Foo.external');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_OBJECT_ADDED');
+      expect(change.message).toEqual("Directive 'external' was added to object 'Foo'");
+    });
+    test('removed directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on OBJECT
+        type Foo @external {
+          a: String
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on OBJECT
+        type Foo {
+          a: String
+        }
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Foo.external');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_OBJECT_REMOVED');
+      expect(change.message).toEqual("Directive 'external' was removed from object 'Foo'");
+    });
+  });
+
+  describe('interface-level directives', () => {
+    test('added directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on INTERFACE
+        interface Foo {
+          a: String
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on INTERFACE
+        interface Foo @external {
+          a: String
+        }
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Foo.external');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_INTERFACE_ADDED');
+      expect(change.message).toEqual("Directive 'external' was added to interface 'Foo'");
+    });
+
+    test('removed directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on INTERFACE
+        interface Foo @external {
+          a: String
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on INTERFACE
+        interface Foo {
+          a: String
+        }
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Foo.external');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Breaking);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_INTERFACE_REMOVED');
+      expect(change.message).toEqual("Directive 'external' was removed from interface 'Foo'");
+    });
+  });
+
+  describe('argument-definition directives', () => {
+    test('added directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on ARGUMENT_DEFINITION
+        type Foo {
+          a(a: String): String
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on ARGUMENT_DEFINITION
+        type Foo {
+          a(a: String @external): String
+        }
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Foo.a.a.external');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_ARGUMENT_DEFINITION_ADDED');
+      expect(change.message).toEqual("Directive 'external' was added to argument 'a'");
+    });
+
+    test('removed directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on ARGUMENT_DEFINITION
+        type Foo {
+          a(a: String @external): String
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on ARGUMENT_DEFINITION
+        type Foo {
+          a(a: String): String
+        }
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Foo.a.a.external');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_ARGUMENT_DEFINITION_REMOVED');
+      expect(change.message).toEqual("Directive 'external' was removed from argument 'Foo.a'");
+    });
+  });
+
+  describe('schema directives', () => {
+    test('added directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on SCHEMA
+        schema {
+          query: Foo
+        }
+        type Foo {
+          a(a: String): String
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on SCHEMA
+        schema @external {
+          query: Foo
+        }
+        type Foo {
+          a(a: String): String
+        }
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Foo.external');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_SCHEMA_ADDED');
+      expect(change.message).toEqual("Directive 'external' was added to schema");
+    });
+    test('removed directive', async () => {
+      const a = buildSchema(/* GraphQL */ `
+        directive @external on SCHEMA
+        schema @external {
+          query: Foo
+        }
+        type Foo {
+          a(a: String): String
+        }
+      `);
+      const b = buildSchema(/* GraphQL */ `
+        directive @external on SCHEMA
+        schema {
+          query: Foo
+        }
+        type Foo {
+          a(a: String): String
+        }
+      `);
+
+      const changes = await diff(a, b);
+      const change = findFirstChangeByPath(changes, 'Foo.external');
+
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.type).toEqual('DIRECTIVE_USAGE_SCHEMA_REMOVED');
+      expect(change.message).toEqual("Directive 'external' was removed from schema");
+    });
+  });
+});

--- a/packages/core/__tests__/diff/enum.test.ts
+++ b/packages/core/__tests__/diff/enum.test.ts
@@ -165,7 +165,7 @@ describe('enum', () => {
     const changes = await diff(a, b);
     const change = findFirstChangeByPath(changes, 'enumA.A');
 
-    expect(changes.length).toEqual(1);
+    expect(changes.length).toEqual(2);
     expect(change.criticality.level).toEqual(CriticalityLevel.NonBreaking);
     expect(change.message).toEqual(`Enum value 'enumA.A' was deprecated with reason 'New Reason'`);
   });
@@ -196,7 +196,7 @@ describe('enum', () => {
     const changes = await diff(a, b);
     const change = findFirstChangeByPath(changes, 'enumA.A');
 
-    expect(changes.length).toEqual(1);
+    expect(changes.length).toEqual(2);
     expect(change.criticality.level).toEqual(CriticalityLevel.NonBreaking);
     expect(change.message).toEqual(`Deprecation reason was removed from enum value 'enumA.A'`);
   });

--- a/packages/core/__tests__/diff/schema.test.ts
+++ b/packages/core/__tests__/diff/schema.test.ts
@@ -799,7 +799,7 @@ test('should work with with missing directive definitions', async () => {
 
   const changes = await diff(schemaA, schemaB);
 
-  expect(changes).toHaveLength(1);
+  expect(changes).toHaveLength(2);
 });
 
 test('adding root type should not be breaking', async () => {

--- a/packages/core/src/diff/changes/change.ts
+++ b/packages/core/src/diff/changes/change.ts
@@ -83,6 +83,31 @@ export const ChangeType = {
   // Union
   UnionMemberRemoved: 'UNION_MEMBER_REMOVED',
   UnionMemberAdded: 'UNION_MEMBER_ADDED',
+  // Directive Usage
+  DirectiveUsageUnionMemberAdded: 'DIRECTIVE_USAGE_UNION_MEMBER_ADDED',
+  DirectiveUsageUnionMemberRemoved: 'DIRECTIVE_USAGE_UNION_MEMBER_REMOVED',
+  DirectiveUsageEnumAdded: 'DIRECTIVE_USAGE_ENUM_ADDED',
+  DirectiveUsageEnumRemoved: 'DIRECTIVE_USAGE_ENUM_REMOVED',
+  DirectiveUsageEnumValueAdded: 'DIRECTIVE_USAGE_ENUM_VALUE_ADDED',
+  DirectiveUsageEnumValueRemoved: 'DIRECTIVE_USAGE_ENUM_VALUE_REMOVED',
+  DirectiveUsageInputObjectAdded: 'DIRECTIVE_USAGE_INPUT_OBJECT_ADDED',
+  DirectiveUsageInputObjectRemoved: 'DIRECTIVE_USAGE_INPUT_OBJECT_REMOVED',
+  DirectiveUsageFieldAdded: 'DIRECTIVE_USAGE_FIELD_ADDED',
+  DirectiveUsageFieldRemoved: 'DIRECTIVE_USAGE_FIELD_REMOVED',
+  DirectiveUsageScalarAdded: 'DIRECTIVE_USAGE_SCALAR_ADDED',
+  DirectiveUsageScalarRemoved: 'DIRECTIVE_USAGE_SCALAR_REMOVED',
+  DirectiveUsageObjectAdded: 'DIRECTIVE_USAGE_OBJECT_ADDED',
+  DirectiveUsageObjectRemoved: 'DIRECTIVE_USAGE_OBJECT_REMOVED',
+  DirectiveUsageInterfaceAdded: 'DIRECTIVE_USAGE_INTERFACE_ADDED',
+  DirectiveUsageInterfaceRemoved: 'DIRECTIVE_USAGE_INTERFACE_REMOVED',
+  DirectiveUsageArgumentDefinitionAdded: 'DIRECTIVE_USAGE_ARGUMENT_DEFINITION_ADDED',
+  DirectiveUsageArgumentDefinitionRemoved: 'DIRECTIVE_USAGE_ARGUMENT_DEFINITION_REMOVED',
+  DirectiveUsageSchemaAdded: 'DIRECTIVE_USAGE_SCHEMA_ADDED',
+  DirectiveUsageSchemaRemoved: 'DIRECTIVE_USAGE_SCHEMA_REMOVED',
+  DirectiveUsageFieldDefinitionAdded: 'DIRECTIVE_USAGE_FIELD_DEFINITION_ADDED',
+  DirectiveUsageFieldDefinitionRemoved: 'DIRECTIVE_USAGE_FIELD_DEFINITION_REMOVED',
+  DirectiveUsageInputFieldDefinitionAdded: 'DIRECTIVE_USAGE_INPUT_FIELD_DEFINITION_ADDED',
+  DirectiveUsageInputFieldDefinitionRemoved: 'DIRECTIVE_USAGE_INPUT_FIELD_DEFINITION_REMOVED',
 } as const;
 
 export type ChangeType = (typeof ChangeType)[keyof typeof ChangeType];
@@ -371,7 +396,7 @@ export type FieldTypeChangedChange = {
 };
 
 export type DirectiveUsageUnionMemberAddedChange = {
-  type: ChangeType.DirectiveUsageUnionMemberAdded;
+  type: typeof ChangeType.DirectiveUsageUnionMemberAdded;
   meta: {
     unionName: string;
     addedUnionMemberTypeName: string;
@@ -380,7 +405,7 @@ export type DirectiveUsageUnionMemberAddedChange = {
 };
 
 export type DirectiveUsageUnionMemberRemovedChange = {
-  type: ChangeType.DirectiveUsageUnionMemberRemoved;
+  type: typeof ChangeType.DirectiveUsageUnionMemberRemoved;
   meta: {
     unionName: string;
     removedUnionMemberTypeName: string;
@@ -595,7 +620,7 @@ export type UnionMemberAddedChange = {
 // Directive Usage
 
 export type DirectiveUsageEnumAddedChange = {
-  type: ChangeType.DirectiveUsageEnumAdded;
+  type: typeof ChangeType.DirectiveUsageEnumAdded;
   meta: {
     enumName: string;
     addedDirectiveName: string;
@@ -603,7 +628,7 @@ export type DirectiveUsageEnumAddedChange = {
 };
 
 export type DirectiveUsageEnumRemovedChange = {
-  type: ChangeType.DirectiveUsageEnumRemoved;
+  type: typeof ChangeType.DirectiveUsageEnumRemoved;
   meta: {
     enumName: string;
     removedDirectiveName: string;
@@ -611,7 +636,7 @@ export type DirectiveUsageEnumRemovedChange = {
 };
 
 export type DirectiveUsageEnumValueAddedChange = {
-  type: ChangeType.DirectiveUsageEnumValueAdded;
+  type: typeof ChangeType.DirectiveUsageEnumValueAdded;
   meta: {
     enumName: string;
     enumValueName: string;
@@ -620,7 +645,7 @@ export type DirectiveUsageEnumValueAddedChange = {
 };
 
 export type DirectiveUsageEnumValueRemovedChange = {
-  type: ChangeType.DirectiveUsageEnumValueRemoved;
+  type: typeof ChangeType.DirectiveUsageEnumValueRemoved;
   meta: {
     enumName: string;
     enumValueName: string;
@@ -629,7 +654,7 @@ export type DirectiveUsageEnumValueRemovedChange = {
 };
 
 export type DirectiveUsageInputObjectdRemovedChange = {
-  type: ChangeType.DirectiveUsageInputObjectRemoved;
+  type: typeof ChangeType.DirectiveUsageInputObjectRemoved;
   meta: {
     inputObjectName: string;
     removedInputFieldName: string;
@@ -640,7 +665,7 @@ export type DirectiveUsageInputObjectdRemovedChange = {
 };
 
 export type DirectiveUsageInputObjectAddedChange = {
-  type: ChangeType.DirectiveUsageInputObjectAdded;
+  type: typeof ChangeType.DirectiveUsageInputObjectAdded;
   meta: {
     inputObjectName: string;
     addedInputFieldName: string;
@@ -651,7 +676,7 @@ export type DirectiveUsageInputObjectAddedChange = {
 };
 
 export type DirectiveUsageInputFieldDefinitionAddedChange = {
-  type: ChangeType.DirectiveUsageInputFieldDefinitionAdded;
+  type: typeof ChangeType.DirectiveUsageInputFieldDefinitionAdded;
   meta: {
     inputObjectName: string;
     inputFieldName: string;
@@ -660,7 +685,7 @@ export type DirectiveUsageInputFieldDefinitionAddedChange = {
 };
 
 export type DirectiveUsageInputFieldDefinitionRemovedChange = {
-  type: ChangeType.DirectiveUsageInputFieldDefinitionRemoved;
+  type: typeof ChangeType.DirectiveUsageInputFieldDefinitionRemoved;
   meta: {
     inputObjectName: string;
     inputFieldName: string;
@@ -669,7 +694,7 @@ export type DirectiveUsageInputFieldDefinitionRemovedChange = {
 };
 
 export type DirectiveUsageFieldAddedChange = {
-  type: ChangeType.DirectiveUsageFieldAdded;
+  type: typeof ChangeType.DirectiveUsageFieldAdded;
   meta: {
     typeName: string;
     fieldName: string;
@@ -678,7 +703,7 @@ export type DirectiveUsageFieldAddedChange = {
 };
 
 export type DirectiveUsageFieldRemovedChange = {
-  type: ChangeType.DirectiveUsageFieldRemoved;
+  type: typeof ChangeType.DirectiveUsageFieldRemoved;
   meta: {
     typeName: string;
     fieldName: string;
@@ -687,7 +712,7 @@ export type DirectiveUsageFieldRemovedChange = {
 };
 
 export type DirectiveUsageScalarAddedChange = {
-  type: ChangeType.DirectiveUsageScalarAdded;
+  type: typeof ChangeType.DirectiveUsageScalarAdded;
   meta: {
     scalarName: string;
     addedDirectiveName: string;
@@ -695,7 +720,7 @@ export type DirectiveUsageScalarAddedChange = {
 };
 
 export type DirectiveUsageScalarRemovedChange = {
-  type: ChangeType.DirectiveUsageScalarRemoved;
+  type: typeof ChangeType.DirectiveUsageScalarRemoved;
   meta: {
     scalarName: string;
     removedDirectiveName: string;
@@ -703,7 +728,7 @@ export type DirectiveUsageScalarRemovedChange = {
 };
 
 export type DirectiveUsageObjectAddedChange = {
-  type: ChangeType.DirectiveUsageObjectAdded;
+  type: typeof ChangeType.DirectiveUsageObjectAdded;
   meta: {
     objectName: string;
     addedDirectiveName: string;
@@ -711,7 +736,7 @@ export type DirectiveUsageObjectAddedChange = {
 };
 
 export type DirectiveUsageObjectRemovedChange = {
-  type: ChangeType.DirectiveUsageObjectRemoved;
+  type: typeof ChangeType.DirectiveUsageObjectRemoved;
   meta: {
     objectName: string;
     removedDirectiveName: string;
@@ -719,7 +744,7 @@ export type DirectiveUsageObjectRemovedChange = {
 };
 
 export type DirectiveUsageInterfaceAddedChange = {
-  type: ChangeType.DirectiveUsageInterfaceAdded;
+  type: typeof ChangeType.DirectiveUsageInterfaceAdded;
   meta: {
     interfaceName: string;
     addedDirectiveName: string;
@@ -727,7 +752,7 @@ export type DirectiveUsageInterfaceAddedChange = {
 };
 
 export type DirectiveUsageSchemaAddedChange = {
-  type: ChangeType.DirectiveUsageSchemaAdded;
+  type: typeof ChangeType.DirectiveUsageSchemaAdded;
   meta: {
     addedDirectiveName: string;
     schemaTypeName: string;
@@ -735,7 +760,7 @@ export type DirectiveUsageSchemaAddedChange = {
 };
 
 export type DirectiveUsageSchemaRemovedChange = {
-  type: ChangeType.DirectiveUsageSchemaRemoved;
+  type: typeof ChangeType.DirectiveUsageSchemaRemoved;
   meta: {
     removedDirectiveName: string;
     schemaTypeName: string;
@@ -743,7 +768,7 @@ export type DirectiveUsageSchemaRemovedChange = {
 };
 
 export type DirectiveUsageFieldDefinitionAddedChange = {
-  type: ChangeType.DirectiveUsageFieldDefinitionAdded;
+  type: typeof ChangeType.DirectiveUsageFieldDefinitionAdded;
   meta: {
     typeName: string;
     fieldName: string;
@@ -752,7 +777,7 @@ export type DirectiveUsageFieldDefinitionAddedChange = {
 };
 
 export type DirectiveUsageFieldDefinitionRemovedChange = {
-  type: ChangeType.DirectiveUsageFieldDefinitionRemoved;
+  type: typeof ChangeType.DirectiveUsageFieldDefinitionRemoved;
   meta: {
     typeName: string;
     fieldName: string;
@@ -761,7 +786,7 @@ export type DirectiveUsageFieldDefinitionRemovedChange = {
 };
 
 export type DirectiveUsageArgumentDefinitionChange = {
-  type: ChangeType.DirectiveUsageArgumentDefinitionAdded;
+  type: typeof ChangeType.DirectiveUsageArgumentDefinitionAdded;
   meta: {
     typeName: string;
     fieldName: string;
@@ -771,7 +796,7 @@ export type DirectiveUsageArgumentDefinitionChange = {
 };
 
 export type DirectiveUsageArgumentDefinitionRemovedChange = {
-  type: ChangeType.DirectiveUsageArgumentDefinitionRemoved;
+  type: typeof ChangeType.DirectiveUsageArgumentDefinitionRemoved;
   meta: {
     typeName: string;
     fieldName: string;
@@ -781,13 +806,12 @@ export type DirectiveUsageArgumentDefinitionRemovedChange = {
 };
 
 export type DirectiveUsageInterfaceRemovedChange = {
-  type: ChangeType.DirectiveUsageInterfaceRemoved;
+  type: typeof ChangeType.DirectiveUsageInterfaceRemoved;
   meta: {
     interfaceName: string;
     removedDirectiveName: string;
   };
 };
-
 type Changes = {
   [ChangeType.TypeAdded]: TypeAddedChange;
   [ChangeType.TypeRemoved]: TypeRemovedChange;

--- a/packages/core/src/diff/changes/change.ts
+++ b/packages/core/src/diff/changes/change.ts
@@ -370,6 +370,24 @@ export type FieldTypeChangedChange = {
   };
 };
 
+export type DirectiveUsageUnionMemberAddedChange = {
+  type: ChangeType.DirectiveUsageUnionMemberAdded;
+  meta: {
+    unionName: string;
+    addedUnionMemberTypeName: string;
+    addedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageUnionMemberRemovedChange = {
+  type: ChangeType.DirectiveUsageUnionMemberRemoved;
+  meta: {
+    unionName: string;
+    removedUnionMemberTypeName: string;
+    removedDirectiveName: string;
+  };
+};
+
 export type FieldArgumentAddedChange = {
   type: typeof ChangeType.FieldArgumentAdded;
   meta: {
@@ -574,6 +592,202 @@ export type UnionMemberAddedChange = {
   };
 };
 
+// Directive Usage
+
+export type DirectiveUsageEnumAddedChange = {
+  type: ChangeType.DirectiveUsageEnumAdded;
+  meta: {
+    enumName: string;
+    addedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageEnumRemovedChange = {
+  type: ChangeType.DirectiveUsageEnumRemoved;
+  meta: {
+    enumName: string;
+    removedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageEnumValueAddedChange = {
+  type: ChangeType.DirectiveUsageEnumValueAdded;
+  meta: {
+    enumName: string;
+    enumValueName: string;
+    addedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageEnumValueRemovedChange = {
+  type: ChangeType.DirectiveUsageEnumValueRemoved;
+  meta: {
+    enumName: string;
+    enumValueName: string;
+    removedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageInputObjectdRemovedChange = {
+  type: ChangeType.DirectiveUsageInputObjectRemoved;
+  meta: {
+    inputObjectName: string;
+    removedInputFieldName: string;
+    isRemovedInputFieldTypeNullable: boolean;
+    removedInputFieldType: string;
+    removedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageInputObjectAddedChange = {
+  type: ChangeType.DirectiveUsageInputObjectAdded;
+  meta: {
+    inputObjectName: string;
+    addedInputFieldName: string;
+    isAddedInputFieldTypeNullable: boolean;
+    addedInputFieldType: string;
+    addedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageInputFieldDefinitionAddedChange = {
+  type: ChangeType.DirectiveUsageInputFieldDefinitionAdded;
+  meta: {
+    inputObjectName: string;
+    inputFieldName: string;
+    addedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageInputFieldDefinitionRemovedChange = {
+  type: ChangeType.DirectiveUsageInputFieldDefinitionRemoved;
+  meta: {
+    inputObjectName: string;
+    inputFieldName: string;
+    removedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageFieldAddedChange = {
+  type: ChangeType.DirectiveUsageFieldAdded;
+  meta: {
+    typeName: string;
+    fieldName: string;
+    addedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageFieldRemovedChange = {
+  type: ChangeType.DirectiveUsageFieldRemoved;
+  meta: {
+    typeName: string;
+    fieldName: string;
+    removedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageScalarAddedChange = {
+  type: ChangeType.DirectiveUsageScalarAdded;
+  meta: {
+    scalarName: string;
+    addedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageScalarRemovedChange = {
+  type: ChangeType.DirectiveUsageScalarRemoved;
+  meta: {
+    scalarName: string;
+    removedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageObjectAddedChange = {
+  type: ChangeType.DirectiveUsageObjectAdded;
+  meta: {
+    objectName: string;
+    addedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageObjectRemovedChange = {
+  type: ChangeType.DirectiveUsageObjectRemoved;
+  meta: {
+    objectName: string;
+    removedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageInterfaceAddedChange = {
+  type: ChangeType.DirectiveUsageInterfaceAdded;
+  meta: {
+    interfaceName: string;
+    addedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageSchemaAddedChange = {
+  type: ChangeType.DirectiveUsageSchemaAdded;
+  meta: {
+    addedDirectiveName: string;
+    schemaTypeName: string;
+  };
+};
+
+export type DirectiveUsageSchemaRemovedChange = {
+  type: ChangeType.DirectiveUsageSchemaRemoved;
+  meta: {
+    removedDirectiveName: string;
+    schemaTypeName: string;
+  };
+};
+
+export type DirectiveUsageFieldDefinitionAddedChange = {
+  type: ChangeType.DirectiveUsageFieldDefinitionAdded;
+  meta: {
+    typeName: string;
+    fieldName: string;
+    addedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageFieldDefinitionRemovedChange = {
+  type: ChangeType.DirectiveUsageFieldDefinitionRemoved;
+  meta: {
+    typeName: string;
+    fieldName: string;
+    removedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageArgumentDefinitionChange = {
+  type: ChangeType.DirectiveUsageArgumentDefinitionAdded;
+  meta: {
+    typeName: string;
+    fieldName: string;
+    argumentName: string;
+    addedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageArgumentDefinitionRemovedChange = {
+  type: ChangeType.DirectiveUsageArgumentDefinitionRemoved;
+  meta: {
+    typeName: string;
+    fieldName: string;
+    argumentName: string;
+    removedDirectiveName: string;
+  };
+};
+
+export type DirectiveUsageInterfaceRemovedChange = {
+  type: ChangeType.DirectiveUsageInterfaceRemoved;
+  meta: {
+    interfaceName: string;
+    removedDirectiveName: string;
+  };
+};
+
 type Changes = {
   [ChangeType.TypeAdded]: TypeAddedChange;
   [ChangeType.TypeRemoved]: TypeRemovedChange;
@@ -647,6 +861,28 @@ type Changes = {
   [ChangeType.FieldDeprecationReasonAdded]: FieldDeprecationReasonAddedChange;
   [ChangeType.FieldDeprecationReasonRemoved]: FieldDeprecationReasonRemovedChange;
   [ChangeType.FieldTypeChanged]: FieldTypeChangedChange;
+  [ChangeType.DirectiveUsageUnionMemberAdded]: DirectiveUsageUnionMemberAddedChange;
+  [ChangeType.DirectiveUsageUnionMemberRemoved]: DirectiveUsageUnionMemberRemovedChange;
+  [ChangeType.DirectiveUsageEnumAdded]: DirectiveUsageEnumAddedChange;
+  [ChangeType.DirectiveUsageEnumRemoved]: DirectiveUsageEnumRemovedChange;
+  [ChangeType.DirectiveUsageEnumValueAdded]: DirectiveUsageEnumValueAddedChange;
+  [ChangeType.DirectiveUsageEnumValueRemoved]: DirectiveUsageEnumValueRemovedChange;
+  [ChangeType.DirectiveUsageInputObjectAdded]: DirectiveUsageInputObjectAddedChange;
+  [ChangeType.DirectiveUsageInputObjectRemoved]: DirectiveUsageInputObjectdRemovedChange;
+  [ChangeType.DirectiveUsageFieldAdded]: DirectiveUsageFieldAddedChange;
+  [ChangeType.DirectiveUsageFieldRemoved]: DirectiveUsageFieldRemovedChange;
+  [ChangeType.DirectiveUsageScalarAdded]: DirectiveUsageScalarAddedChange;
+  [ChangeType.DirectiveUsageScalarRemoved]: DirectiveUsageScalarRemovedChange;
+  [ChangeType.DirectiveUsageObjectAdded]: DirectiveUsageObjectAddedChange;
+  [ChangeType.DirectiveUsageObjectRemoved]: DirectiveUsageObjectRemovedChange;
+  [ChangeType.DirectiveUsageInterfaceAdded]: DirectiveUsageInterfaceAddedChange;
+  [ChangeType.DirectiveUsageInterfaceRemoved]: DirectiveUsageInterfaceRemovedChange;
+  [ChangeType.DirectiveUsageArgumentDefinitionAdded]: DirectiveUsageArgumentDefinitionChange;
+  [ChangeType.DirectiveUsageArgumentDefinitionRemoved]: DirectiveUsageArgumentDefinitionRemovedChange;
+  [ChangeType.DirectiveUsageSchemaAdded]: DirectiveUsageSchemaAddedChange;
+  [ChangeType.DirectiveUsageSchemaRemoved]: DirectiveUsageSchemaRemovedChange;
+  [ChangeType.DirectiveUsageFieldDefinitionAdded]: DirectiveUsageFieldDefinitionAddedChange;
+  [ChangeType.DirectiveUsageFieldDefinitionRemoved]: DirectiveUsageFieldDefinitionRemovedChange;
 };
 
 export type SerializableChange = Changes[keyof Changes];

--- a/packages/core/src/diff/changes/directive-usage.ts
+++ b/packages/core/src/diff/changes/directive-usage.ts
@@ -1,0 +1,500 @@
+import {
+  ConstDirectiveNode,
+  GraphQLArgument,
+  GraphQLEnumType,
+  GraphQLEnumValue,
+  GraphQLField,
+  GraphQLInputField,
+  GraphQLInputObjectType,
+  GraphQLInterfaceType,
+  GraphQLObjectType,
+  GraphQLScalarType,
+  GraphQLSchema,
+  GraphQLUnionType,
+  Kind,
+} from 'graphql';
+import {
+  Change,
+  ChangeType,
+  CriticalityLevel,
+  DirectiveUsageArgumentDefinitionChange,
+  DirectiveUsageArgumentDefinitionRemovedChange,
+  DirectiveUsageEnumAddedChange,
+  DirectiveUsageEnumRemovedChange,
+  DirectiveUsageEnumValueAddedChange,
+  DirectiveUsageEnumValueRemovedChange,
+  DirectiveUsageFieldDefinitionAddedChange,
+  DirectiveUsageFieldDefinitionRemovedChange,
+  DirectiveUsageInputObjectAddedChange,
+  DirectiveUsageInputObjectdRemovedChange,
+  DirectiveUsageInterfaceAddedChange,
+  DirectiveUsageInterfaceRemovedChange,
+  DirectiveUsageObjectAddedChange,
+  DirectiveUsageObjectRemovedChange,
+  DirectiveUsageScalarAddedChange,
+  DirectiveUsageScalarRemovedChange,
+  DirectiveUsageSchemaAddedChange,
+  DirectiveUsageSchemaRemovedChange,
+  DirectiveUsageUnionMemberAddedChange,
+  DirectiveUsageUnionMemberRemovedChange,
+} from './change.js';
+
+function addedSpecialDirective(directiveName: string, forceReturn: CriticalityLevel) {
+  if (directiveName === 'deprecated') {
+    return CriticalityLevel.NonBreaking;
+  }
+  if (directiveName === 'oneOf') {
+    return CriticalityLevel.Breaking;
+  }
+  return forceReturn;
+}
+
+function removedSpecialDirective(directiveName: string, forceReturn: CriticalityLevel) {
+  if (directiveName === 'deprecated') {
+    return CriticalityLevel.NonBreaking;
+  }
+  if (directiveName === 'oneOf') {
+    return CriticalityLevel.NonBreaking;
+  }
+  return forceReturn;
+}
+
+type KindToPayload = {
+  [Kind.ENUM_TYPE_DEFINITION]: {
+    input: GraphQLEnumType;
+    change: DirectiveUsageEnumAddedChange | DirectiveUsageEnumRemovedChange;
+  };
+  [Kind.FIELD_DEFINITION]: {
+    input: {
+      field: GraphQLField<any, any, any>;
+      parentType: GraphQLInterfaceType | GraphQLObjectType<any, any>;
+    };
+    change: DirectiveUsageFieldDefinitionAddedChange | DirectiveUsageFieldDefinitionRemovedChange;
+  };
+  [Kind.UNION_TYPE_DEFINITION]: {
+    input: GraphQLUnionType;
+    change: DirectiveUsageUnionMemberAddedChange | DirectiveUsageUnionMemberRemovedChange;
+  };
+  [Kind.ENUM_VALUE_DEFINITION]: {
+    input: {
+      type: GraphQLEnumType;
+      value: GraphQLEnumValue;
+    };
+    change: DirectiveUsageEnumValueAddedChange | DirectiveUsageEnumValueRemovedChange;
+  };
+  [Kind.SCHEMA_DEFINITION]: {
+    input: GraphQLSchema;
+    change: DirectiveUsageSchemaAddedChange | DirectiveUsageSchemaRemovedChange;
+  };
+  [Kind.SCALAR_TYPE_DEFINITION]: {
+    input: GraphQLScalarType;
+    change: DirectiveUsageScalarAddedChange | DirectiveUsageScalarRemovedChange;
+  };
+  [Kind.OBJECT]: {
+    input: GraphQLObjectType;
+    change: DirectiveUsageObjectAddedChange | DirectiveUsageObjectRemovedChange;
+  };
+  [Kind.INTERFACE_TYPE_DEFINITION]: {
+    input: GraphQLInterfaceType;
+    change: DirectiveUsageInterfaceAddedChange | DirectiveUsageInterfaceRemovedChange;
+  };
+  [Kind.INPUT_OBJECT_TYPE_DEFINITION]: {
+    input: GraphQLInputObjectType;
+    change: DirectiveUsageInputObjectAddedChange | DirectiveUsageInputObjectdRemovedChange;
+  };
+  [Kind.INPUT_VALUE_DEFINITION]: {
+    input: {
+      field: GraphQLInputField;
+      type: GraphQLInputObjectType;
+    };
+    change: DirectiveUsageArgumentDefinitionChange | DirectiveUsageArgumentDefinitionRemovedChange;
+  };
+  [Kind.ARGUMENT]: {
+    input: {
+      field: GraphQLField<any, any, any>;
+      type: GraphQLObjectType | GraphQLInterfaceType;
+      argument: GraphQLArgument;
+    };
+    change: DirectiveUsageArgumentDefinitionChange | DirectiveUsageArgumentDefinitionRemovedChange;
+  };
+};
+
+export function directiveUsageAdded<K extends keyof KindToPayload>(
+  kind: K,
+  directive: ConstDirectiveNode,
+  payload: KindToPayload[K]['input'],
+): Change {
+  if (isOfKind(kind, Kind.ARGUMENT, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageArgumentDefinitionAdded,
+      criticality: {
+        level: addedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was added to argument '${payload.argument.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was added to argument '${payload.argument.name}'`,
+      meta: {
+        argumentName: payload.argument.name,
+        addedDirectiveName: directive.name.value,
+        fieldName: payload.field.name,
+        typeName: payload.type.name,
+      },
+      path: [
+        payload.type.name,
+        payload.field.name,
+        payload.argument.name,
+        directive.name.value,
+      ].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.INPUT_VALUE_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageArgumentDefinitionAdded,
+      criticality: {
+        level: addedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was added to argument '${payload.field.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was added to argument '${payload.field.name}'`,
+      meta: {
+        argumentName: payload.field.name,
+        addedDirectiveName: directive.name.value,
+        fieldName: payload.type.name,
+        typeName: payload.type.name,
+      },
+      path: [payload.type.name, payload.field.name, directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.INPUT_OBJECT_TYPE_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageInputObjectAdded,
+      criticality: {
+        level: addedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was added to input object '${payload.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was added to input object '${payload.name}'`,
+      meta: {
+        inputObjectName: payload.name,
+        addedDirectiveName: directive.name.value,
+      },
+      path: [payload.name, directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.INTERFACE_TYPE_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageInterfaceAdded,
+      criticality: {
+        level: addedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was added to interface '${payload.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was added to interface '${payload.name}'`,
+      meta: {
+        interfaceName: payload.name,
+        addedDirectiveName: directive.name.value,
+      },
+      path: [payload.name, directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.OBJECT, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageObjectAdded,
+      criticality: {
+        level: addedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was added to object '${payload.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was added to object '${payload.name}'`,
+      meta: {
+        objectName: payload.name,
+        addedDirectiveName: directive.name.value,
+      },
+      path: [payload.name, directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.ENUM_TYPE_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageEnumAdded,
+      criticality: {
+        level: addedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was added to enum '${payload.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was added to enum '${payload.name}'`,
+      meta: {
+        enumName: payload.name,
+        addedDirectiveName: directive.name.value,
+      },
+      path: [payload.name, directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.FIELD_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageFieldDefinitionAdded,
+      criticality: {
+        level: addedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was added to field '${payload.parentType.name}.${payload.field.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was added to field '${payload.parentType.name}.${payload.field.name}'`,
+      meta: {
+        typeName: payload.parentType.name,
+        fieldName: payload.field.name,
+        addedDirectiveName: directive.name.value,
+      },
+      path: [payload.parentType.name, payload.field.name, directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.UNION_TYPE_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageUnionMemberAdded,
+      criticality: {
+        level: addedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was added to union member '${payload.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was added to union member '${payload.name}'`,
+      meta: {
+        unionName: payload.name,
+        addedDirectiveName: directive.name.value,
+        addedUnionMemberTypeName: payload.name,
+      },
+      path: [payload.name, directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.ENUM_VALUE_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageEnumValueAdded,
+      criticality: {
+        level: addedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was added to enum value '${payload.type.name}.${payload.value.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was added to enum value '${payload.type.name}.${payload.value.name}'`,
+      meta: {
+        enumName: payload.type.name,
+        enumValueName: payload.value.name,
+        addedDirectiveName: directive.name.value,
+      },
+      path: [payload.type.name, payload.value.name, directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.SCHEMA_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageSchemaAdded,
+      criticality: {
+        level: addedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was added to schema`,
+      },
+      message: `Directive '${directive.name.value}' was added to schema`,
+      meta: {
+        addedDirectiveName: directive.name.value,
+        schemaTypeName: payload.getQueryType()?.name || '',
+      },
+      path: [payload.getQueryType()?.name || '', directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.SCALAR_TYPE_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageScalarAdded,
+      criticality: {
+        level: addedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was added to scalar '${payload.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was added to scalar '${payload.name}'`,
+      meta: {
+        scalarName: payload.name,
+        addedDirectiveName: directive.name.value,
+      },
+      path: [payload.name, directive.name.value].join('.'),
+    } as const;
+  }
+
+  return {} as any;
+}
+
+export function directiveUsageRemoved<K extends keyof KindToPayload>(
+  kind: K,
+  directive: ConstDirectiveNode,
+  payload: KindToPayload[K]['input'],
+): Change {
+  if (isOfKind(kind, Kind.ARGUMENT, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageArgumentDefinitionRemoved,
+      criticality: {
+        level: removedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was removed from argument '${payload.type.name}.${payload.field.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was removed from argument '${payload.type.name}.${payload.field.name}'`,
+      meta: {
+        argumentName: payload.argument.name,
+        removedDirectiveName: directive.name.value,
+        fieldName: payload.field.name,
+        typeName: payload.type.name,
+      },
+      path: [
+        payload.type.name,
+        payload.field.name,
+        payload.argument.name,
+        directive.name.value,
+      ].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.INPUT_VALUE_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageArgumentDefinitionRemoved,
+      criticality: {
+        level: removedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was removed from input value '${payload.type.name}.${payload.field.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was removed from input value '${payload.type.name}.${payload.field.name}'`,
+      meta: {
+        argumentName: payload.field.name,
+        removedDirectiveName: directive.name.value,
+        fieldName: payload.type.name,
+        typeName: payload.type.name,
+      },
+      path: [payload.type.name, payload.field.name, directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.INPUT_OBJECT_TYPE_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageInputObjectRemoved,
+      criticality: {
+        level: removedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was removed from input object '${payload.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was removed from input object '${payload.name}'`,
+      meta: {
+        inputObjectName: payload.name,
+        removedDirectiveName: directive.name.value,
+      },
+      path: [payload.name, directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.INTERFACE_TYPE_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageInterfaceRemoved,
+      criticality: {
+        level: removedSpecialDirective(directive.name.value, CriticalityLevel.Breaking),
+        reason: `Directive '${directive.name.value}' was removed from interface '${payload.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was removed from interface '${payload.name}'`,
+      meta: {
+        interfaceName: payload.name,
+        removedDirectiveName: directive.name.value,
+      },
+      path: [payload.name, directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.OBJECT, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageObjectRemoved,
+      criticality: {
+        level: removedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was removed from object '${payload.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was removed from object '${payload.name}'`,
+      meta: {
+        objectName: payload.name,
+        removedDirectiveName: directive.name.value,
+      },
+      path: [payload.name, directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.ENUM_TYPE_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageEnumRemoved,
+      criticality: {
+        level: removedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was removed from enum '${payload.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was removed from enum '${payload.name}'`,
+      meta: {
+        enumName: payload.name,
+        removedDirectiveName: directive.name.value,
+      },
+      path: [payload.name, directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.FIELD_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageFieldDefinitionRemoved,
+      criticality: {
+        level: removedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was removed from field '${payload.parentType.name}.${payload.field.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was removed from field '${payload.parentType.name}.${payload.field.name}'`,
+      meta: {
+        typeName: payload.parentType.name,
+        fieldName: payload.field.name,
+        removedDirectiveName: directive.name.value,
+      },
+      path: [payload.parentType.name, payload.field.name, directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.UNION_TYPE_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageUnionMemberRemoved,
+      criticality: {
+        level: removedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was removed from union member '${payload.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was removed from union member '${payload.name}'`,
+      meta: {
+        unionName: payload.name,
+        removedDirectiveName: directive.name.value,
+        removedUnionMemberTypeName: payload.name,
+      },
+      path: [payload.name, directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.ENUM_VALUE_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageEnumValueRemoved,
+      criticality: {
+        level: removedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was removed from enum value '${payload.type.name}.${payload.value.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was removed from enum value '${payload.type.name}.${payload.value.name}'`,
+      meta: {
+        enumName: payload.type.name,
+        enumValueName: payload.value.name,
+        removedDirectiveName: directive.name.value,
+      },
+      path: [payload.type.name, payload.value.name, directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.SCHEMA_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageSchemaRemoved,
+      criticality: {
+        level: removedSpecialDirective(directive.name.value, CriticalityLevel.Dangerous),
+        reason: `Directive '${directive.name.value}' was removed from schema`,
+      },
+      message: `Directive '${directive.name.value}' was removed from schema`,
+      meta: {
+        removedDirectiveName: directive.name.value,
+        schemaTypeName: payload.getQueryType()?.name || '',
+      },
+      path: [payload.getQueryType()?.name || '', directive.name.value].join('.'),
+    } as const;
+  }
+  if (isOfKind(kind, Kind.SCALAR_TYPE_DEFINITION, payload)) {
+    return {
+      type: ChangeType.DirectiveUsageScalarRemoved,
+      criticality: {
+        level: removedSpecialDirective(directive.name.value, CriticalityLevel.Breaking),
+        reason: `Directive '${directive.name.value}' was removed from scalar '${payload.name}'`,
+      },
+      message: `Directive '${directive.name.value}' was removed from scalar '${payload.name}'`,
+      meta: {
+        scalarName: payload.name,
+        removedDirectiveName: directive.name.value,
+      },
+      path: [payload.name, directive.name.value].join('.'),
+    } as const;
+  }
+
+  return {} as any;
+}
+
+function isOfKind<K extends keyof KindToPayload>(
+  kind: keyof KindToPayload,
+  expectedKind: K,
+  _value: any,
+): _value is KindToPayload[K]['input'] {
+  return kind === expectedKind;
+}

--- a/packages/core/src/diff/enum.ts
+++ b/packages/core/src/diff/enum.ts
@@ -1,5 +1,6 @@
-import { GraphQLEnumType } from 'graphql';
+import { GraphQLEnumType, Kind } from 'graphql';
 import { compareLists, isNotEqual, isVoid } from '../utils/compare.js';
+import { directiveUsageAdded, directiveUsageRemoved } from './changes/directive-usage.js';
 import {
   enumValueAdded,
   enumValueDeprecationReasonAdded,
@@ -39,6 +40,34 @@ export function changesInEnum(
           addChange(enumValueDeprecationReasonChanged(newEnum, oldValue, newValue));
         }
       }
+
+      compareLists(oldValue.astNode?.directives || [], newValue.astNode?.directives || [], {
+        onAdded(directive) {
+          addChange(
+            directiveUsageAdded(Kind.ENUM_VALUE_DEFINITION, directive, {
+              type: newEnum,
+              value: newValue,
+            }),
+          );
+        },
+        onRemoved(directive) {
+          addChange(
+            directiveUsageRemoved(Kind.ENUM_VALUE_DEFINITION, directive, {
+              type: oldEnum,
+              value: oldValue,
+            }),
+          );
+        },
+      });
+    },
+  });
+
+  compareLists(oldEnum.astNode?.directives || [], newEnum.astNode?.directives || [], {
+    onAdded(directive) {
+      addChange(directiveUsageAdded(Kind.ENUM_TYPE_DEFINITION, directive, newEnum));
+    },
+    onRemoved(directive) {
+      addChange(directiveUsageRemoved(Kind.ENUM_TYPE_DEFINITION, directive, newEnum));
     },
   });
 }

--- a/packages/core/src/diff/field.ts
+++ b/packages/core/src/diff/field.ts
@@ -1,7 +1,8 @@
-import { GraphQLField, GraphQLInterfaceType, GraphQLObjectType } from 'graphql';
+import { GraphQLField, GraphQLInterfaceType, GraphQLObjectType, Kind } from 'graphql';
 import { compareLists, isNotEqual, isVoid } from '../utils/compare.js';
 import { isDeprecated } from '../utils/is-deprecated.js';
 import { changesInArgument } from './argument.js';
+import { directiveUsageAdded, directiveUsageRemoved } from './changes/directive-usage.js';
 import {
   fieldArgumentAdded,
   fieldArgumentRemoved,
@@ -64,6 +65,25 @@ export function changesInField(
     },
     onMutual(arg) {
       changesInArgument(type, oldField, arg.oldVersion, arg.newVersion, addChange);
+    },
+  });
+
+  compareLists(oldField.astNode?.directives || [], newField.astNode?.directives || [], {
+    onAdded(directive) {
+      addChange(
+        directiveUsageAdded(Kind.FIELD_DEFINITION, directive, {
+          parentType: type,
+          field: newField,
+        }),
+      );
+    },
+    onRemoved(arg) {
+      addChange(
+        directiveUsageRemoved(Kind.FIELD_DEFINITION, arg, {
+          parentType: type,
+          field: oldField,
+        }),
+      );
     },
   });
 }

--- a/packages/core/src/diff/interface.ts
+++ b/packages/core/src/diff/interface.ts
@@ -1,5 +1,6 @@
-import { GraphQLInterfaceType } from 'graphql';
+import { GraphQLInterfaceType, Kind } from 'graphql';
 import { compareLists } from '../utils/compare.js';
+import { directiveUsageAdded, directiveUsageRemoved } from './changes/directive-usage.js';
 import { fieldAdded, fieldRemoved } from './changes/field.js';
 import { changesInField } from './field.js';
 import { AddChange } from './schema.js';
@@ -18,6 +19,14 @@ export function changesInInterface(
     },
     onMutual(field) {
       changesInField(oldInterface, field.oldVersion, field.newVersion, addChange);
+    },
+  });
+  compareLists(oldInterface.astNode?.directives || [], newInterface.astNode?.directives || [], {
+    onAdded(directive) {
+      addChange(directiveUsageAdded(Kind.INTERFACE_TYPE_DEFINITION, directive, newInterface));
+    },
+    onRemoved(directive) {
+      addChange(directiveUsageRemoved(Kind.INTERFACE_TYPE_DEFINITION, directive, oldInterface));
     },
   });
 }

--- a/packages/core/src/diff/object.ts
+++ b/packages/core/src/diff/object.ts
@@ -1,5 +1,6 @@
-import { GraphQLObjectType } from 'graphql';
+import { GraphQLObjectType, Kind } from 'graphql';
 import { compareLists } from '../utils/compare.js';
+import { directiveUsageAdded, directiveUsageRemoved } from './changes/directive-usage.js';
 import { fieldAdded, fieldRemoved } from './changes/field.js';
 import { objectTypeInterfaceAdded, objectTypeInterfaceRemoved } from './changes/object.js';
 import { changesInField } from './field.js';
@@ -34,6 +35,15 @@ export function changesInObject(
     },
     onMutual(f) {
       changesInField(oldType, f.oldVersion, f.newVersion, addChange);
+    },
+  });
+
+  compareLists(oldType.astNode?.directives || [], newType.astNode?.directives || [], {
+    onAdded(directive) {
+      addChange(directiveUsageAdded(Kind.OBJECT, directive, newType));
+    },
+    onRemoved(directive) {
+      addChange(directiveUsageRemoved(Kind.OBJECT, directive, oldType));
     },
   });
 }

--- a/packages/core/src/diff/rules/ignore-usage-directives.ts
+++ b/packages/core/src/diff/rules/ignore-usage-directives.ts
@@ -1,0 +1,24 @@
+import { ChangeType } from '../changes/change.js';
+import { Rule } from './types.js';
+
+interface IgnoreDirectivesConfig {
+  ignoredDirectives: string[];
+}
+
+export const ignoreDirectives: Rule<IgnoreDirectivesConfig> = ({ changes, config }) => {
+  if (!config?.ignoredDirectives?.length) {
+    return changes;
+  }
+  const ignoredDirectiveSet = new Set(config.ignoredDirectives);
+
+  const filteredChanges = changes.filter(change => {
+    if (change.type === ChangeType && change.path) {
+      const directiveName = change.path.split('.')[1];
+      return !ignoredDirectiveSet.has(directiveName);
+    }
+
+    return true;
+  });
+
+  return filteredChanges;
+};

--- a/packages/core/src/diff/rules/index.ts
+++ b/packages/core/src/diff/rules/index.ts
@@ -3,3 +3,4 @@ export * from './dangerous-breaking.js';
 export * from './ignore-description-changes.js';
 export * from './safe-unreachable.js';
 export * from './suppress-removal-of-deprecated-field.js';
+export * from './ignore-usage-directives.js';

--- a/packages/core/src/diff/scalar.ts
+++ b/packages/core/src/diff/scalar.ts
@@ -1,0 +1,19 @@
+import { GraphQLScalarType, Kind } from 'graphql';
+import { compareLists } from '../utils/compare.js';
+import { directiveUsageAdded, directiveUsageRemoved } from './changes/directive-usage.js';
+import { AddChange } from './schema.js';
+
+export function changesInScalar(
+  oldScalar: GraphQLScalarType,
+  newScalar: GraphQLScalarType,
+  addChange: AddChange,
+) {
+  compareLists(oldScalar.astNode?.directives || [], newScalar.astNode?.directives || [], {
+    onAdded(directive) {
+      addChange(directiveUsageAdded(Kind.SCALAR_TYPE_DEFINITION, directive, newScalar));
+    },
+    onRemoved(directive) {
+      addChange(directiveUsageRemoved(Kind.SCALAR_TYPE_DEFINITION, directive, oldScalar));
+    },
+  });
+}

--- a/packages/core/src/diff/union.ts
+++ b/packages/core/src/diff/union.ts
@@ -1,5 +1,6 @@
-import { GraphQLUnionType } from 'graphql';
+import { GraphQLUnionType, Kind } from 'graphql';
 import { compareLists } from '../utils/compare.js';
+import { directiveUsageAdded, directiveUsageRemoved } from './changes/directive-usage.js';
 import { unionMemberAdded, unionMemberRemoved } from './changes/union.js';
 import { AddChange } from './schema.js';
 
@@ -17,6 +18,15 @@ export function changesInUnion(
     },
     onRemoved(t) {
       addChange(unionMemberRemoved(oldUnion, t));
+    },
+  });
+
+  compareLists(oldUnion.astNode?.directives || [], newUnion.astNode?.directives || [], {
+    onAdded(directive) {
+      addChange(directiveUsageAdded(Kind.UNION_TYPE_DEFINITION, directive, newUnion));
+    },
+    onRemoved(directive) {
+      addChange(directiveUsageRemoved(Kind.UNION_TYPE_DEFINITION, directive, oldUnion));
     },
   });
 }

--- a/packages/core/src/utils/compare.ts
+++ b/packages/core/src/utils/compare.ts
@@ -1,3 +1,5 @@
+import { NameNode } from 'graphql';
+
 export function keyMap<T>(list: readonly T[], keyFn: (item: T) => string): Record<string, T> {
   return list.reduce((map, item) => {
     map[keyFn(item)] = item;
@@ -51,7 +53,15 @@ export function diffArrays<T>(a: T[] | readonly T[], b: T[] | readonly T[]): T[]
   return a.filter(c => !b.some(d => isEqual(d, c)));
 }
 
-export function compareLists<T extends { name: string }>(
+function extractName(name: string | NameNode): string {
+  if (typeof name === 'string') {
+    return name;
+  }
+
+  return name.value;
+}
+
+export function compareLists<T extends { name: string | NameNode }>(
   oldList: readonly T[],
   newList: readonly T[],
   callbacks?: {
@@ -60,15 +70,15 @@ export function compareLists<T extends { name: string }>(
     onMutual?(t: { newVersion: T; oldVersion: T }): void;
   },
 ) {
-  const oldMap = keyMap(oldList, ({ name }) => name);
-  const newMap = keyMap(newList, ({ name }) => name);
+  const oldMap = keyMap(oldList, ({ name }) => extractName(name));
+  const newMap = keyMap(newList, ({ name }) => extractName(name));
 
   const added: T[] = [];
   const removed: T[] = [];
   const mutual: Array<{ newVersion: T; oldVersion: T }> = [];
 
   for (const oldItem of oldList) {
-    const newItem = newMap[oldItem.name];
+    const newItem = newMap[extractName(oldItem.name)];
     if (newItem === undefined) {
       removed.push(oldItem);
     } else {
@@ -80,7 +90,7 @@ export function compareLists<T extends { name: string }>(
   }
 
   for (const newItem of newList) {
-    if (oldMap[newItem.name] === undefined) {
+    if (oldMap[extractName(newItem.name)] === undefined) {
       added.push(newItem);
     }
   }


### PR DESCRIPTION
Closes #2618 

- [x]  SCHEMA = 'SCHEMA',
- [x]   SCALAR = 'SCALAR',
- [x]   OBJECT = 'OBJECT',
- [x]   FIELD_DEFINITION = 'FIELD_DEFINITION',
- [x]   ARGUMENT_DEFINITION = 'ARGUMENT_DEFINITION',
- [x]   INTERFACE = 'INTERFACE',
- [x]   UNION = 'UNION',
- [x]   ENUM = 'ENUM',
- [x]   ENUM_VALUE = 'ENUM_VALUE',
- [x]   INPUT_OBJECT = 'INPUT_OBJECT',
- [x]   INPUT_FIELD_DEFINITION = 'INPUT_FIELD_DEFINITION',
