### PR TITLE
Fix typo in `onUsage` arg name

### DIFF
--- a/.changeset/khaki-spies-smile.md
+++ b/.changeset/khaki-spies-smile.md
@@ -1,0 +1,5 @@
+---
+'@graphql-inspector/action': patch
+---
+
+Fix typo in onUsage arg name

--- a/packages/action/src/run.ts
+++ b/packages/action/src/run.ts
@@ -40,7 +40,7 @@ export async function run() {
   const endpoint: string = core.getInput('endpoint');
   const approveLabel: string = core.getInput('approve-label') || 'approved-breaking-change';
   const rulesList = getInputAsArray('rules') || [];
-  const onUsage = core.getInput('getUsage');
+  const onUsage = core.getInput('onUsage');
 
   const octokit = github.getOctokit(token);
 


### PR DESCRIPTION
Fixing a bug that prevented the `checkUsage` rule from working with this action