### PR TITLE
Add documentation for the --ignore option

### DIFF
--- a/website/src/pages/docs/commands/validate.mdx
+++ b/website/src/pages/docs/commands/validate.mdx
@@ -48,6 +48,7 @@ graphql-inspector validate DOCUMENTS SCHEMA
 - `--complexityDepthCostFactor <n>` - Depth cost factor config to use with maxComplexityScore
   (default: `1.5`)
 - `--filter <s>` - show warnings and errors only for a file (or a list of files)
+- `--ignore <s>` - ignore and do not load these files (supports glob)
 - `--silent` - silent mode
 - `--output <s>` - writes errors to a file
 - `--onlyErrors` - shows only errors


### PR DESCRIPTION
## Description

This adds a line to the documentation for the `--ignore` option on the `validate` command's Flags.

Fixes https://github.com/kamilkisiela/graphql-inspector/issues/2693

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

https://the-guild.dev/graphql/inspector/docs/commands/validate#flags

## How Has This Been Tested?

?? Not sure how to test changes to the documentation site.

**Test Environment**:

N/A

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A
