### PR TITLE
fix: issue: [2717] coverage calculation improvements

### DIFF
--- a/.changeset/eighty-dingos-end.md
+++ b/.changeset/eighty-dingos-end.md
@@ -1,0 +1,6 @@
+---
+'@graphql-inspector/coverage-command': minor
+'@graphql-inspector/core': minor
+---
+
+Fix: coverage calculation improvements: Covered Queries & Covered Mutations & Covered Subscriptions

--- a/packages/commands/coverage/src/index.ts
+++ b/packages/commands/coverage/src/index.ts
@@ -193,12 +193,28 @@ function renderCoverage(coverage: SchemaCoverage) {
       result: String(coverage.stats.numQueries > 0 ? coverage.stats.numQueries : '0'),
     },
     {
+      method: 'Covered Queries',
+      result: String(coverage.stats.numCoveredQueries > 0 ? coverage.stats.numCoveredQueries : '0'),
+    },
+    {
       method: 'Total Mutations',
       result: String(coverage.stats.numMutations > 0 ? coverage.stats.numMutations : '0'),
     },
     {
+      method: 'Covered Mutations',
+      result: String(
+        coverage.stats.numCoveredMutations > 0 ? coverage.stats.numCoveredMutations : '0',
+      ),
+    },
+    {
       method: 'Total Subscriptions',
       result: String(coverage.stats.numSubscriptions > 0 ? coverage.stats.numSubscriptions : '0'),
+    },
+    {
+      method: 'Covered Subscriptions',
+      result: String(
+        coverage.stats.numCoveredSubscriptions > 0 ? coverage.stats.numCoveredSubscriptions : '0',
+      ),
     },
   ];
   Logger.table(logStatsResult);

--- a/packages/core/__tests__/coverage/coverage.test.ts
+++ b/packages/core/__tests__/coverage/coverage.test.ts
@@ -23,6 +23,7 @@ describe('coverage', () => {
 
     type Mutation {
       submitPost(title: String!, author: String!): Post!
+      removePost(id: Int!): Post!
     }
 
     schema {
@@ -56,6 +57,10 @@ describe('coverage', () => {
           id
         }
       }
+
+      mutation removePost {
+        removePost(id: 1)
+      }
     `);
 
     const results = coverage(schema, [new Source(print(doc))]);
@@ -78,7 +83,7 @@ describe('coverage', () => {
     expect(results.types.Identifiable.children.id.hits).toEqual(1);
     expect(results.types.Identifiable.children.createdAt.hits).toEqual(0);
     // Mutation
-    expect(results.types.Mutation.hits).toEqual(1);
+    expect(results.types.Mutation.hits).toEqual(2);
     expect(results.types.Mutation.children.submitPost.hits).toEqual(1);
     expect(results.types.Mutation.children.submitPost.children.title.hits).toEqual(1);
     expect(results.types.Mutation.children.submitPost.children.author.hits).toEqual(1);
@@ -87,8 +92,12 @@ describe('coverage', () => {
     expect(results.stats.numTypes).toEqual(4);
     expect(results.stats.numTypesCovered).toEqual(4);
     expect(results.stats.numTypesCoveredFully).toEqual(1);
-    expect(results.stats.numFields).toEqual(14);
-    expect(results.stats.numFiledsCovered).toEqual(10);
+    expect(results.stats.numFields).toEqual(16);
+    expect(results.stats.numFiledsCovered).toEqual(12);
+    expect(results.stats.numQueries).toEqual(3);
+    expect(results.stats.numCoveredQueries).toEqual(2);
+    expect(results.stats.numMutations).toEqual(2);
+    expect(results.stats.numCoveredMutations).toEqual(2);
   });
 
   test('no coverage', () => {
@@ -121,11 +130,14 @@ describe('coverage', () => {
     expect(results.stats.numTypes).toEqual(4);
     expect(results.stats.numTypesCovered).toEqual(0);
     expect(results.stats.numTypesCoveredFully).toEqual(0);
-    expect(results.stats.numFields).toEqual(14);
+    expect(results.stats.numFields).toEqual(16);
     expect(results.stats.numFiledsCovered).toEqual(0);
-    expect(results.stats.numQueries).toEqual(1);
+    expect(results.stats.numQueries).toEqual(3);
+    expect(results.stats.numCoveredQueries).toEqual(0);
     expect(results.stats.numSubscriptions).toEqual(0);
-    expect(results.stats.numMutations).toEqual(1);
+    expect(results.stats.numCoveredSubscriptions).toEqual(0);
+    expect(results.stats.numMutations).toEqual(2);
+    expect(results.stats.numCoveredMutations).toEqual(0);
   });
 
   test('introspection', () => {

--- a/packages/core/src/coverage/index.ts
+++ b/packages/core/src/coverage/index.ts
@@ -61,8 +61,11 @@ export interface SchemaCoverage {
     numTypesCovered: number;
     numFields: number;
     numQueries: number;
+    numCoveredQueries: number;
     numMutations: number;
+    numCoveredMutations: number;
     numSubscriptions: number;
+    numCoveredSubscriptions: number;
     numFieldsCovered: number;
     numFiledsCovered: number; // @deprecated will be removed in next major version
   };
@@ -85,8 +88,11 @@ export function coverage(schema: GraphQLSchema, sources: Source[]): SchemaCovera
       numFieldsCovered: 0,
       numFiledsCovered: 0,
       numQueries: 0,
+      numCoveredQueries: 0,
       numMutations: 0,
+      numCoveredMutations: 0,
       numSubscriptions: 0,
+      numCoveredSubscriptions: 0,
     },
   };
   const typeMap = schema.getTypeMap();
@@ -107,6 +113,18 @@ export function coverage(schema: GraphQLSchema, sources: Source[]): SchemaCovera
         const typeCoverage = coverage.types[parent.name];
         const fieldCoverage = typeCoverage.children[fieldDef.name];
         const locations = fieldCoverage.locations[sourceName];
+
+        switch (typeCoverage.type.name) {
+          case 'Query':
+            coverage.stats.numCoveredQueries++;
+            break;
+          case 'Mutation':
+            coverage.stats.numCoveredMutations++;
+            break;
+          case 'Subscription':
+            coverage.stats.numCoveredSubscriptions++;
+            break;
+        }
 
         typeCoverage.hits++;
         fieldCoverage.hits++;
@@ -146,23 +164,23 @@ export function coverage(schema: GraphQLSchema, sources: Source[]): SchemaCovera
           children: {},
         };
 
-        if (isObjectType(type) || isInterfaceType(type)) {
-          switch (type.name) {
-            case 'Query':
-              coverage.stats.numQueries++;
-              break;
-            case 'Mutation':
-              coverage.stats.numMutations++;
-              break;
-            case 'Subscription':
-              coverage.stats.numSubscriptions++;
-              break;
-          }
-        }
-
         const fieldMap = type.getFields();
 
         for (const fieldname in fieldMap) {
+          if (isObjectType(type) || isInterfaceType(type)) {
+            switch (type.name) {
+              case 'Query':
+                coverage.stats.numQueries++;
+                break;
+              case 'Mutation':
+                coverage.stats.numMutations++;
+                break;
+              case 'Subscription':
+                coverage.stats.numSubscriptions++;
+                break;
+            }
+          }
+
           const field = fieldMap[fieldname];
 
           typeCoverage.children[field.name] = {


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

As a user of coverage feature I faced need to see total and covered numbers of queries and mutations.
So I decided to apply improvements. 

Fixes # (2717)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## How Has This Been Tested?

I updated existing unit tests.

**Test Environment**:

- OS:
- `@graphql-inspector/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
