### PR TITLE
add more information on union fields being removed

### DIFF
--- a/.changeset/lazy-lemons-vanish.md
+++ b/.changeset/lazy-lemons-vanish.md
@@ -1,0 +1,6 @@
+---
+'@graphql-inspector/core': minor
+---
+
+Updated removing field message to contain more information on why its a breaking change such as if
+the field is a union or indirectly referenced.

--- a/packages/core/src/diff/changes/field.ts
+++ b/packages/core/src/diff/changes/field.ts
@@ -39,7 +39,7 @@ export function fieldRemovedFromMeta(args: FieldRemovedChange) {
       level: CriticalityLevel.Breaking,
       reason: args.meta.isRemovedFieldDeprecated
         ? `Removing a deprecated field is a breaking change. Before removing it, you may want to look at the field's usage to see the impact of removing the field.`
-        : `Removing a field is a breaking change. It is preferable to deprecate the field before removing it.`,
+        : `Removing a field is a breaking change. It is preferable to deprecate the field before removing it. This applies removed union fields as well as it affects the __typename field which can break your GraphQL consumers.`,
     },
     message: buildFieldRemovedMessage(args.meta),
     meta: args.meta,

--- a/packages/core/src/diff/changes/field.ts
+++ b/packages/core/src/diff/changes/field.ts
@@ -39,7 +39,11 @@ export function fieldRemovedFromMeta(args: FieldRemovedChange) {
       level: CriticalityLevel.Breaking,
       reason: args.meta.isRemovedFieldDeprecated
         ? `Removing a deprecated field is a breaking change. Before removing it, you may want to look at the field's usage to see the impact of removing the field.`
+<<<<<<< Updated upstream
         : `Removing a field is a breaking change. It is preferable to deprecate the field before removing it. This applies removed union fields as well as it affects the __typename field which can break your GraphQL consumers.`,
+=======
+        : `Removing a field is a breaking change. It is preferable to deprecate the field before removing it. This applies to removed union fields as well, since removal breaks client operations that contain fragments that reference the removed type through direct (... on RemovedType) or indirect means such as __typename in the consumers.`,
+>>>>>>> Stashed changes
     },
     message: buildFieldRemovedMessage(args.meta),
     meta: args.meta,

--- a/packages/core/src/diff/changes/field.ts
+++ b/packages/core/src/diff/changes/field.ts
@@ -39,11 +39,7 @@ export function fieldRemovedFromMeta(args: FieldRemovedChange) {
       level: CriticalityLevel.Breaking,
       reason: args.meta.isRemovedFieldDeprecated
         ? `Removing a deprecated field is a breaking change. Before removing it, you may want to look at the field's usage to see the impact of removing the field.`
-<<<<<<< Updated upstream
-        : `Removing a field is a breaking change. It is preferable to deprecate the field before removing it. This applies removed union fields as well as it affects the __typename field which can break your GraphQL consumers.`,
-=======
         : `Removing a field is a breaking change. It is preferable to deprecate the field before removing it. This applies to removed union fields as well, since removal breaks client operations that contain fragments that reference the removed type through direct (... on RemovedType) or indirect means such as __typename in the consumers.`,
->>>>>>> Stashed changes
     },
     message: buildFieldRemovedMessage(args.meta),
     meta: args.meta,


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

These integration tests will need to be updated as well for hive:

https://github.com/graphql-hive/console/blob/10f91e2f956fb96bd5abfa250ab0197e9891f975/integration-tests/tests/api/schema/delete.spec.ts#L212

https://github.com/graphql-hive/console/blob/10f91e2f956fb96bd5abfa250ab0197e9891f975/packages/services/api/src/modules/alerts/providers/adapters/msteams.spec.ts#L55

## Description
Updated removal field text to be:
`Removing a field is a breaking change. It is preferable to deprecate the field before removing it. This applies removed union fields as well as it affects the __typename field which can break your GraphQL consumers.`

Fixes # https://github.com/graphql-hive/console/issues/6125

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [X] `pnpm test`

**Test Environment**:

- OS: Windows
- `@graphql-inspector/...`:
- NodeJS:  v22.12.0

## Checklist:

- [X] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [X] I have performed a self-review of my own code
- [  ] I have commented my code, particularly in hard-to-understand areas
- [  ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [  ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments
