### PR TITLE
Fix validate command not logging filename with only deprecations

### DIFF
--- a/packages/commands/validate/__tests__/validate-command.test.ts
+++ b/packages/commands/validate/__tests__/validate-command.test.ts
@@ -11,6 +11,7 @@ const schema = buildSchema(/* GraphQL */ `
     title: String
     createdAt: String
     modifiedAt: String
+    deprecatedTitle: String @deprecated(reason: "Will be deleted")
   }
 
   type Query {
@@ -59,6 +60,16 @@ const validate = createCommand({
             }
           `),
           location: 'valid-document.graphql',
+        },
+        {
+          document: parse(/* GraphQL */ `
+            query post {
+              post {
+                deprecatedTitle
+              }
+            }
+          `),
+          location: 'with-deprecated-only.graphql',
         },
       ];
     },
@@ -116,4 +127,11 @@ describe('validate', () => {
 
     expect(spyReporter).not.toHaveBeenCalledNormalized('document.graphql:');
   });
+
+  test('should log deprecation when file has only deprecation', async () => {
+    await mockCommand(validate, 'validate "*.graphql" schema.graphql');
+
+    expect(spyReporter).toHaveBeenCalledNormalized('in with-deprecated-only.graphql');
+    expect(spyReporter).toHaveBeenCalledNormalized('The field Post.deprecatedTitle is deprecated. Will be deleted');
+  })
 });

--- a/packages/commands/validate/src/index.ts
+++ b/packages/commands/validate/src/index.ts
@@ -366,7 +366,7 @@ function printInvalidDocuments(
   }
 
   for (const doc of invalidDocuments) {
-    if (doc.errors.length) {
+    if (doc[listKey].length) {
       for (const line of renderErrors(doc.source.name, doc[listKey], isError)) {
         Logger.log(line);
       }


### PR DESCRIPTION
_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

printInvalidDocuments checked always checked whether errors field of an invalid document was not empty before rendering deprecated fields usage. This meant that if a file with operation that used a deprecated field did not have any errors, there would be a message "Detected 1 document with deprecated fields:" without listing the file or the deprecation warning itself.

Fixes #2883

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Added relevant unit test for the change. Tested it on local machine via creating 2 files, one with schema with deprecated field and one with operation that uses said deprecated field.

**Test Environment**:

- OS:
- `@graphql-inspector/...`:
- NodeJS:

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [~] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
