### PR TITLE
export directiveRepeatableAddedFromMeta and directiveRepeatableRemovedFromMeta

### DIFF
--- a/.changeset/old-buckets-arrive.md
+++ b/.changeset/old-buckets-arrive.md
@@ -1,0 +1,5 @@
+---
+'@graphql-inspector/core': patch
+---
+
+export directiveRepeatableAddedFromMeta and directiveRepeatableRemovedFromMeta

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,6 +72,8 @@ export {
   directiveArgumentDescriptionChangedFromMeta,
   directiveArgumentDefaultValueChangedFromMeta,
   directiveArgumentTypeChangedFromMeta,
+  directiveRepeatableRemovedFromMeta,
+  directiveRepeatableAddedFromMeta,
 } from './diff/changes/directive.js';
 export {
   enumValueRemovedFromMeta,


### PR DESCRIPTION
Yet another missing export discovered. The from meta functions are used in deserializing saved records from Hive console's DB.