### PR TITLE
Change hash generator

### DIFF
--- a/.changeset/stupid-bikes-shop.md
+++ b/.changeset/stupid-bikes-shop.md
@@ -1,0 +1,6 @@
+---
+'@graphql-inspector/compare-changes': minor
+---
+
+Export a generateChangeHash function for quickly evaluating changes for possible equality. This is
+useful when storing changes in a database

--- a/packages/compare-changes/__tests__/index.test.ts
+++ b/packages/compare-changes/__tests__/index.test.ts
@@ -1352,6 +1352,21 @@ describe('generateChangeHash', () => {
     expect(generateChangeHash(a)).not.toBe(generateChangeHash(b));
   });
 
+  it('ignores starting and ending whitespace in metadata', () => {
+    const a: Change<'TYPE_REMOVED'> = {
+      type: 'TYPE_REMOVED',
+      path: 'p',
+      meta: { removedTypeName: 'A' },
+      message: 'Example',
+      criticality: { level: CriticalityLevel.NonBreaking },
+    };
+    const b: Change<'TYPE_REMOVED'> = {
+      ...a,
+      meta: { ...a.meta, removedTypeName: ' A ' },
+    };
+    expect(generateChangeHash(a)).toBe(generateChangeHash(b));
+  });
+
   it('generates a different hash when the path differs', () => {
     const a: Change<'TYPE_REMOVED'> = {
       type: 'TYPE_REMOVED',

--- a/packages/compare-changes/__tests__/index.test.ts
+++ b/packages/compare-changes/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { Kind } from 'graphql';
 import { CriticalityLevel, type Change, type TypeOfChangeType } from '@graphql-inspector/core';
-import { isChangeEqual, requiredMatchMetaMap } from '../src/index';
+import { generateChangeHash, isChangeEqual, requiredMatchMetaMap } from '../src/index';
 
 describe('isChangeEqual', () => {
   describe('Directive Changes', () => {
@@ -1308,5 +1308,60 @@ describe('isChangeEqual', () => {
         );
       });
     });
+  });
+});
+
+describe('generateChangeHash', () => {
+  it('generates a short hash', () => {
+    const a: Change<'TYPE_REMOVED'> = {
+      type: 'TYPE_REMOVED',
+      path: 'p',
+      meta: { removedTypeName: 'A' },
+      message: 'Example',
+      criticality: { level: CriticalityLevel.NonBreaking },
+    };
+    expect(generateChangeHash(a)).toMatchInlineSnapshot(`"TYPE_REMOVED:p:65"`);
+  });
+
+  it('should generate the same hash when given the same input', () => {
+    const change: Change<'TYPE_REMOVED'> = {
+      type: 'TYPE_REMOVED',
+      path: 'p',
+      meta: { removedTypeName: 'T' },
+      message: 'Example',
+      criticality: { level: CriticalityLevel.NonBreaking },
+    };
+    expect(generateChangeHash(change)).toBe(generateChangeHash({ ...change, meta: { ...change.meta } }));
+  });
+
+  // note that this is is not guaranteed because of the hashing algorithm, but it is highly likely
+  it('generates a different hash when critical metadata differs', () => {
+    const a: Change<'TYPE_REMOVED'> = {
+      type: 'TYPE_REMOVED',
+      path: 'p',
+      meta: { removedTypeName: 'A' },
+      message: 'Example',
+      criticality: { level: CriticalityLevel.NonBreaking },
+    };
+    const b: Change<'TYPE_REMOVED'> = {
+      ...a,
+      meta: { ...a.meta, removedTypeName: 'B' },
+    };
+    expect(generateChangeHash(a)).not.toBe(generateChangeHash(b));
+  });
+
+  it('generates a different hash when the path differs', () => {
+    const a: Change<'TYPE_REMOVED'> = {
+      type: 'TYPE_REMOVED',
+      path: 'p',
+      meta: { removedTypeName: 'A' },
+      message: 'Example',
+      criticality: { level: CriticalityLevel.NonBreaking },
+    };
+    const b: Change<'TYPE_REMOVED'> = {
+      ...a,
+      path: 'q',
+    };
+    expect(generateChangeHash(a)).not.toBe(generateChangeHash(b));
   });
 });

--- a/packages/compare-changes/__tests__/index.test.ts
+++ b/packages/compare-changes/__tests__/index.test.ts
@@ -1309,6 +1309,20 @@ describe('isChangeEqual', () => {
       });
     });
   });
+
+  test('ignores starting and ending spaces in metadata', () => {
+    const meta = { argumentName: 'a', fieldName: 'f', newDefaultValue: 'v', typeName: 'T' };
+    const a: Change<'FIELD_ARGUMENT_DEFAULT_CHANGED'> = {
+      type: 'FIELD_ARGUMENT_DEFAULT_CHANGED',
+      path: 'p',
+      meta,
+      message: 'Example',
+      criticality: { level: CriticalityLevel.NonBreaking },
+    };
+    expect(
+      isChangeEqual(a, { ...a, meta: { ...meta, newDefaultValue: ` ${meta.newDefaultValue} ` } }),
+    ).toBe(true);
+  });
 });
 
 describe('generateChangeHash', () => {

--- a/packages/compare-changes/__tests__/index.test.ts
+++ b/packages/compare-changes/__tests__/index.test.ts
@@ -1331,7 +1331,9 @@ describe('generateChangeHash', () => {
       message: 'Example',
       criticality: { level: CriticalityLevel.NonBreaking },
     };
-    expect(generateChangeHash(change)).toBe(generateChangeHash({ ...change, meta: { ...change.meta } }));
+    expect(generateChangeHash(change)).toBe(
+      generateChangeHash({ ...change, meta: { ...change.meta } }),
+    );
   });
 
   // note that this is is not guaranteed because of the hashing algorithm, but it is highly likely

--- a/packages/compare-changes/src/index.ts
+++ b/packages/compare-changes/src/index.ts
@@ -8,7 +8,7 @@ import type { Change, TypeOfChangeType } from '@graphql-inspector/core';
  * happening, but DIRECTIVE_ADDED does include metadata for repeatability... This should
  * likely be deprecated from that change type to keep these changes discrete. Same goes for
  * directive locations.
- * 
+ *
  * WARNING -- This list should never change or else the hash algorithm will produce different results.
  */
 export const requiredMatchMetaMap: {
@@ -190,11 +190,10 @@ export function isChangeEqual<T extends TypeOfChangeType, Y extends TypeOfChange
  * guaranteed to be unique so use `isChangeEqual` on match.
  */
 export function generateChangeHash<ChangeType extends TypeOfChangeType>(change: {
-    type: ChangeType;
-    meta: Change<ChangeType>['meta']
-    path?: string | null | undefined;
-  }
-) {
+  type: ChangeType;
+  meta: Change<ChangeType>['meta'];
+  path?: string | null | undefined;
+}) {
   const required = requiredMatchMetaMap[change.type];
   if (!required) {
     // this should not occur
@@ -202,7 +201,9 @@ export function generateChangeHash<ChangeType extends TypeOfChangeType>(change: 
   }
 
   // extract required match meta data values
-  const metaValues = required.map(fieldName => change.meta[fieldName as keyof Change<ChangeType>['meta']]);
+  const metaValues = required.map(
+    fieldName => change.meta[fieldName as keyof Change<ChangeType>['meta']],
+  );
   return `${change.type}:${change.path ?? ''}:${hashCode(metaValues.join('|'))}`;
 }
 
@@ -213,9 +214,9 @@ export function generateChangeHash<ChangeType extends TypeOfChangeType>(change: 
 function hashCode(str: string): number {
   let hash = 0;
   for (let i = 0; i < str.length; i++) {
-      let chr = str.charCodeAt(i);
-      hash = (hash << 5) - hash + chr;
-      hash |= 0;
+    let chr = str.charCodeAt(i);
+    hash = (hash << 5) - hash + chr;
+    hash |= 0;
   }
   return hash;
 }

--- a/packages/compare-changes/src/index.ts
+++ b/packages/compare-changes/src/index.ts
@@ -9,7 +9,8 @@ import type { Change, TypeOfChangeType } from '@graphql-inspector/core';
  * likely be deprecated from that change type to keep these changes discrete. Same goes for
  * directive locations.
  *
- * WARNING -- This list should never change or else the hash algorithm will produce different results.
+ * WARNING -- This list should be append only and the arrays should never change or else the
+ * hash algorithm will produce different results.
  */
 export const requiredMatchMetaMap: {
   [ChangeType in TypeOfChangeType]: Array<keyof Change<ChangeType>['meta']>;

--- a/packages/compare-changes/src/index.ts
+++ b/packages/compare-changes/src/index.ts
@@ -182,7 +182,7 @@ export function isChangeEqual<T extends TypeOfChangeType, Y extends TypeOfChange
     // this should not occur
     throw new Error('Unhandled change type found');
   }
-  return required.every(key => a.meta[key] === b.meta[key]);
+  return required.every(key => String(a.meta[key]).trim() === String(b.meta[key]).trim());
 }
 
 /**

--- a/packages/compare-changes/src/index.ts
+++ b/packages/compare-changes/src/index.ts
@@ -214,8 +214,7 @@ export function generateChangeHash<ChangeType extends TypeOfChangeType>(change: 
 function hashCode(str: string): number {
   let hash = 0;
   for (let i = 0; i < str.length; i++) {
-    let chr = str.charCodeAt(i);
-    hash = (hash << 5) - hash + chr;
+    hash = (hash << 5) - hash + str.charCodeAt(i);
     hash |= 0;
   }
   return hash;

--- a/packages/compare-changes/src/index.ts
+++ b/packages/compare-changes/src/index.ts
@@ -202,8 +202,8 @@ export function generateChangeHash<ChangeType extends TypeOfChangeType>(change: 
   }
 
   // extract required match meta data values
-  const metaValues = required.map(
-    fieldName => String(change.meta[fieldName as keyof Change<ChangeType>['meta']]).trim(),
+  const metaValues = required.map(fieldName =>
+    String(change.meta[fieldName as keyof Change<ChangeType>['meta']]).trim(),
   );
   return `${change.type}:${change.path ?? ''}:${hashCode(metaValues.join('|'))}`;
 }

--- a/packages/compare-changes/src/index.ts
+++ b/packages/compare-changes/src/index.ts
@@ -203,7 +203,7 @@ export function generateChangeHash<ChangeType extends TypeOfChangeType>(change: 
 
   // extract required match meta data values
   const metaValues = required.map(
-    fieldName => change.meta[fieldName as keyof Change<ChangeType>['meta']],
+    fieldName => String(change.meta[fieldName as keyof Change<ChangeType>['meta']]).trim(),
   );
   return `${change.type}:${change.path ?? ''}:${hashCode(metaValues.join('|'))}`;
 }

--- a/packages/compare-changes/src/index.ts
+++ b/packages/compare-changes/src/index.ts
@@ -8,9 +8,11 @@ import type { Change, TypeOfChangeType } from '@graphql-inspector/core';
  * happening, but DIRECTIVE_ADDED does include metadata for repeatability... This should
  * likely be deprecated from that change type to keep these changes discrete. Same goes for
  * directive locations.
+ * 
+ * WARNING -- This list should never change or else the hash algorithm will produce different results.
  */
 export const requiredMatchMetaMap: {
-  [changeType in TypeOfChangeType]: Array<keyof Change<changeType>['meta']>;
+  [ChangeType in TypeOfChangeType]: Array<keyof Change<ChangeType>['meta']>;
 } = {
   DIRECTIVE_ADDED: ['addedDirectiveName'],
   DIRECTIVE_ARGUMENT_ADDED: [
@@ -180,4 +182,40 @@ export function isChangeEqual<T extends TypeOfChangeType, Y extends TypeOfChange
     throw new Error('Unhandled change type found');
   }
   return required.every(key => a.meta[key] === b.meta[key]);
+}
+
+/**
+ * Computes a hash from the type, path, and metadata so that changes
+ * can be quickly looked up (i.e. in a database). Hashes are not
+ * guaranteed to be unique so use `isChangeEqual` on match.
+ */
+export function generateChangeHash<ChangeType extends TypeOfChangeType>(change: {
+    type: ChangeType;
+    meta: Change<ChangeType>['meta']
+    path?: string | null | undefined;
+  }
+) {
+  const required = requiredMatchMetaMap[change.type];
+  if (!required) {
+    // this should not occur
+    throw new Error('Unhandled change type found');
+  }
+
+  // extract required match meta data values
+  const metaValues = required.map(fieldName => change.meta[fieldName as keyof Change<ChangeType>['meta']]);
+  return `${change.type}:${change.path ?? ''}:${hashCode(metaValues.join('|'))}`;
+}
+
+/**
+ * Generates a non-secure 32bit integer hash from a string.
+ * This is fast but has a higher potential for collisions than cryptographic hashes.
+ */
+function hashCode(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+      let chr = str.charCodeAt(i);
+      hash = (hash << 5) - hash + chr;
+      hash |= 0;
+  }
+  return hash;
 }


### PR DESCRIPTION
## Description

To be used for looking up newly published changes against proposed schema changes in hive schema registry.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Unit tests

## Checklist:

- [X] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
