### PR TITLE
Update action.yml runs.using from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,5 +57,5 @@ outputs:
   changes:
     description: Total number of changes
 runs:
-  using: node20
+  using: node24
   main: action/index.js


### PR DESCRIPTION
## Description

GitHub Actions is deprecating the Node.js 20 runtime. Node24 will become the default on June 2, 2026, and node20 will be removed in fall 2026.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

This PR updates `action.yml` from `runs.using: node20` to `runs.using: node24`.

Same transition as #2719 (node16 → node20).

Fixes #2948

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

N/A — single-line change in `action.yml`, no application logic affected.

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules