### PR TITLE
Consider adding a new input with a default to be dangerous

### DIFF
--- a/.changeset/witty-pugs-think.md
+++ b/.changeset/witty-pugs-think.md
@@ -2,4 +2,4 @@
 '@graphql-inspector/core': patch
 ---
 
-Consider adding a new input with a default to be dangerous
+"INPUT_FIELD_ADDED" is now classified as Dangerous (was NonBreaking) when the added field has a default value, since rolling deploys can expose consumers to the default before producers are ready.

--- a/.changeset/witty-pugs-think.md
+++ b/.changeset/witty-pugs-think.md
@@ -1,0 +1,5 @@
+---
+'@graphql-inspector/core': patch
+---
+
+Consider adding a new input with a default to be dangerous

--- a/packages/core/__tests__/diff/input.test.ts
+++ b/packages/core/__tests__/diff/input.test.ts
@@ -53,7 +53,7 @@ describe('input', () => {
       `);
 
       const change = findFirstChangeByPath(await diff(a, b), 'Foo.b');
-      expect(change.criticality.level).toEqual(CriticalityLevel.NonBreaking);
+      expect(change.criticality.level).toEqual(CriticalityLevel.Dangerous);
       expect(change.type).toEqual('INPUT_FIELD_ADDED');
       expect(change.meta).toMatchObject({
         addedFieldDefault: '"B"',

--- a/packages/core/src/diff/changes/input.ts
+++ b/packages/core/src/diff/changes/input.ts
@@ -81,7 +81,7 @@ export function inputFieldAddedFromMeta(args: InputFieldAddedChange) {
     criticality = {
       level: CriticalityLevel.Dangerous,
       reason:
-        'Adding a new field with a default value has the potential to break if using rolling deploys. The gateway may start passing the value before all subgraphs are updated.',
+        'Adding a field with a default value can change runtime behavior for clients that previously omitted it, and during rolling deploys consumers may receive the new default before producers are ready to handle it.',
     };
   }
 

--- a/packages/core/src/diff/changes/input.ts
+++ b/packages/core/src/diff/changes/input.ts
@@ -54,20 +54,40 @@ export function buildInputFieldAddedMessage(args: InputFieldAddedChange['meta'])
 }
 
 export function inputFieldAddedFromMeta(args: InputFieldAddedChange) {
+  let criticality: {
+    level: CriticalityLevel;
+    reason?: string;
+  };
+  const addedNullableWithoutDefault =
+    args.meta.isAddedInputFieldTypeNullable && args.meta.addedFieldDefault === undefined;
+
+  if (args.meta.addedToNewType) {
+    criticality = {
+      level: CriticalityLevel.NonBreaking,
+      reason: 'The field is being added to a new type.',
+    };
+  } else if (addedNullableWithoutDefault) {
+    criticality = {
+      level: CriticalityLevel.NonBreaking,
+      reason: 'The field is nullable and no default is set.',
+    };
+  } else if (args.meta.addedFieldDefault === undefined) {
+    criticality = {
+      level: CriticalityLevel.Breaking,
+      reason:
+        'Adding a required input field to an existing input object type is a breaking change because it will cause existing uses of this input object type to error.',
+    };
+  } else {
+    criticality = {
+      level: CriticalityLevel.Dangerous,
+      reason:
+        'Adding a new field with a default value has the potential to break if using rolling deploys. The gateway may start passing the value before all subgraphs are updated.',
+    };
+  }
+
   return {
     type: ChangeType.InputFieldAdded,
-    criticality:
-      args.meta.addedToNewType ||
-      args.meta.isAddedInputFieldTypeNullable ||
-      args.meta.addedFieldDefault !== undefined
-        ? {
-            level: CriticalityLevel.NonBreaking,
-          }
-        : {
-            level: CriticalityLevel.Breaking,
-            reason:
-              'Adding a required input field to an existing input object type is a breaking change because it will cause existing uses of this input object type to error.',
-          },
+    criticality,
     message: buildInputFieldAddedMessage(args.meta),
     meta: args.meta,
     path: [args.meta.inputName, args.meta.addedInputFieldName].join('.'),


### PR DESCRIPTION
## Description

Consider adding a new input with a default to be dangerous

Internal link: https://linear.app/the-guild/issue/CONSOLE-2034/add-check-for-default-parameters-in-hive-schema-validation

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

See unit test change.

## Checklist:

- [X] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
